### PR TITLE
feat: Implement Milestone M3 (SETUP screen) with UI refinements

### DIFF
--- a/.biomeignore
+++ b/.biomeignore
@@ -1,0 +1,1 @@
+src/index.css

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
   },
   "files": {
     "ignoreUnknown": true,
-    "includes": ["**", "!**/node_modules", "!**/dist"]
+    "includes": ["**", "!**/node_modules", "!**/dist", "!src/index.css"]
   },
   "formatter": {
     "enabled": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "mix-poker",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@tailwindcss/postcss": "^4.1.18",
         "clsx": "^2.1.1",
         "immer": "^11.0.1",
@@ -491,6 +494,60 @@
       ],
       "engines": {
         "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2185,7 +2242,6 @@
       "integrity": "sha512-QsCdAUHAmiDeKeaNojb1OHOPF7NjcWPBR7obdu3NwH2a/oyQaLg5d0aaCy/9My6CdPChYF07dvz5chaXBGaD4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "^20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -2692,6 +2748,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2894,6 +2951,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@tailwindcss/postcss": "^4.1.18",
     "clsx": "^2.1.1",
     "immer": "^11.0.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { useAppStore } from "./app/store/appStore";
+import { SetupPage } from "./ui/pages/SetupPage";
+
+const App: React.FC = () => {
+  const initialize = useAppStore((state) => state.initialize);
+  const screen = useAppStore((state) => state.ui.screen);
+
+  React.useEffect(() => {
+    initialize();
+  }, [initialize]);
+
+  return (
+    <div className="min-h-screen bg-background text-foreground flex flex-col">
+      {/* Routing logic based on screen state */}
+      {screen === "SETUP" && <SetupPage />}
+      {screen === "PLAY" && (
+        <div className="p-8 text-center">PLAY SCREEN (Coming Soon)</div>
+      )}
+    </div>
+  );
+};
+
+export default App;

--- a/src/domain/game.ts
+++ b/src/domain/game.ts
@@ -1,15 +1,53 @@
 import type {
   DealState,
+  GamePlayer,
   GameState,
   GameType,
   PlayerId,
   RotationRule,
+  Stakes,
 } from "./types";
 
 export interface StartDealParams {
   rngSeed: string; // 将来使用
   seatOrder: PlayerId[];
 }
+
+/**
+ * 初期GameStateを作成する純関数
+ */
+export const createInitialGameState = (
+  players: GamePlayer[],
+  rotation: RotationRule,
+  stakes: Stakes,
+): GameState => {
+  const gameId = `game-${Date.now()}`;
+
+  // 初期スタックはMVPでは固定（例: 200BB or input）
+  // ここではplayersのstackプロパティに何も持たせてないので、score.stacksで管理する前提
+  // PlayerConfigListでは name/id/kind しか設定していないので、defaultsを与える
+  const initialStacks: Record<string, number> = {};
+  // デフォルト 200 * BigBet としておく (例)
+  const startingStack = stakes.bigBet * 100; // MVP default
+
+  players.forEach((p) => {
+    initialStacks[p.id] = startingStack;
+  });
+
+  return {
+    gameId,
+    players,
+    score: {
+      stacks: initialStacks,
+    },
+    stakes,
+    rotation,
+    dealIndex: 0, // 0-based, first deal is 0
+    currentDeal: null,
+    dealHistory: [],
+    gameFinished: false,
+  };
+};
 
 /**
  * 現在のディール番号に基づいてゲーム種別を決定する
@@ -47,7 +85,9 @@ export const startNewDeal = (
         seat: i,
         kind: pInfo ? pInfo.kind : "human",
         active: true,
-        stack: game.score.stacks[pid] ?? 0, // ※スコアモデルによる。MVPは一旦0開始 or 引き継ぎ
+        // 前回のスタックを引き継ぐ（currentDeal初期化時はまだpot移動前だが、
+        // startNewDealは「次のディール」なので、前のディールの結果反映後のGameを渡す前提）
+        stack: game.score.stacks[pid] ?? 0,
         committedTotal: 0,
         committedThisStreet: 0,
       };
@@ -56,7 +96,7 @@ export const startNewDeal = (
     bringIn: game.stakes.bringIn,
     smallBet: game.stakes.smallBet,
     bigBet: game.stakes.bigBet,
-    street: "3rd",
+    street: "3rd", // Stud系は3rd開始
     bringInIndex: 0, // 仮: カード配布後に決定
     currentActorIndex: 0, // 仮: カード配布後に決定
     pot: 0,

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,114 @@
+@import "tailwindcss";
+
+@theme {
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+}
+
+:root {
+  --background: #ffffff;
+  --foreground: #09090b;
+
+  --card: #ffffff;
+  --card-foreground: #09090b;
+
+  --popover: #ffffff;
+  --popover-foreground: #09090b;
+
+  --primary: #18181b;
+  --primary-foreground: #fafafa;
+
+  --secondary: #f4f4f5;
+  --secondary-foreground: #18181b;
+
+  --muted: #f4f4f5;
+  --muted-foreground: #71717a;
+
+  --accent: #f4f4f5;
+  --accent-foreground: #18181b;
+
+  --destructive: #ef4444;
+  --destructive-foreground: #fafafa;
+
+  --border: #e4e4e7;
+  --input: #e4e4e7;
+  --ring: #18181b;
+
+  --radius: 0.5rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #09090b;
+    --foreground: #fafafa;
+
+    --card: #09090b;
+    --card-foreground: #fafafa;
+
+    --popover: #09090b;
+    --popover-foreground: #fafafa;
+
+    --primary: #fafafa;
+    --primary-foreground: #18181b;
+
+    --secondary: #27272a;
+    --secondary-foreground: #fafafa;
+
+    --muted: #27272a;
+    --muted-foreground: #a1a1aa;
+
+    --accent: #27272a;
+    --accent-foreground: #fafafa;
+
+    --destructive: #7f1d1d;
+    --destructive-foreground: #fafafa;
+
+    --border: #27272a;
+    --input: #27272a;
+    --ring: #d4d4d8;
+  }
+}
+
+body {
+  background-color: var(--background);
+  color: var(--foreground);
+  font-family:
+    "Inter",
+    ui-sans-serif,
+    system-ui,
+    sans-serif,
+    "Apple Color Emoji",
+    "Segoe UI Emoji",
+    "Segoe UI Symbol",
+    "Noto Color Emoji";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+const root = document.getElementById("root");
+if (root) {
+  ReactDOM.createRoot(root).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  );
+}

--- a/src/ui/components/setup/GameTypeSelector.tsx
+++ b/src/ui/components/setup/GameTypeSelector.tsx
@@ -1,0 +1,176 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical, Plus, X } from "lucide-react";
+import type React from "react";
+
+import type { GameType } from "../../../domain/types";
+import { getGameTypeLabel } from "../../utils/labelHelper";
+
+interface Props {
+  selectedGames: GameType[];
+  onChange: (games: GameType[]) => void;
+}
+
+const ALL_GAMES: GameType[] = ["studHi", "razz", "stud8"];
+
+// --- Sortable Item Component ---
+function SortableGameItem({
+  game,
+  onRemove,
+  canRemove,
+}: {
+  game: GameType;
+  onRemove: (g: GameType) => void;
+  canRemove: boolean;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: game });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 10 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`flex items-center justify-between p-3 bg-muted/50 rounded-lg border border-border ${
+        isDragging ? "opacity-50 shadow-lg" : ""
+      }`}
+    >
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          className="cursor-grab hover:text-foreground text-muted-foreground outline-none touch-none"
+          {...attributes}
+          {...listeners}
+          title="Drag to reorder"
+        >
+          <GripVertical size={18} />
+        </button>
+        <span className="font-medium text-sm">{getGameTypeLabel(game)}</span>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onRemove(game)}
+        disabled={!canRemove}
+        className="p-1 text-destructive hover:bg-destructive/10 rounded disabled:opacity-30 transition-colors"
+        title="Remove"
+      >
+        <X size={16} />
+      </button>
+    </div>
+  );
+}
+
+// --- Main Component ---
+export const GameTypeSelector: React.FC<Props> = ({
+  selectedGames,
+  onChange,
+}) => {
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (active.id !== over?.id && over) {
+      const oldIndex = selectedGames.indexOf(active.id as GameType);
+      const newIndex = selectedGames.indexOf(over.id as GameType);
+      onChange(arrayMove(selectedGames, oldIndex, newIndex));
+    }
+  };
+
+  const handleToggle = (game: GameType) => {
+    if (selectedGames.includes(game)) {
+      if (selectedGames.length > 1) {
+        onChange(selectedGames.filter((g) => g !== game));
+      }
+    } else {
+      onChange([...selectedGames, game]);
+    }
+  };
+
+  return (
+    <div className="space-y-4 p-4 border rounded-xl shadow-sm bg-card">
+      <h3 className="text-lg font-semibold">採用種目と順序</h3>
+
+      {/* DnD List */}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <div className="space-y-2">
+          <SortableContext
+            items={selectedGames}
+            strategy={verticalListSortingStrategy}
+          >
+            {selectedGames.map((game) => (
+              <SortableGameItem
+                key={game}
+                game={game}
+                onRemove={() => handleToggle(game)}
+                canRemove={selectedGames.length > 1}
+              />
+            ))}
+          </SortableContext>
+        </div>
+      </DndContext>
+
+      {/* Available Games (Add) */}
+      <div className="flex flex-wrap gap-2 pt-2 border-t text-sm">
+        <span className="w-full text-xs text-muted-foreground">追加候補:</span>
+        {ALL_GAMES.map((game) => {
+          const isSelected = selectedGames.includes(game);
+          if (isSelected) return null;
+          return (
+            <button
+              type="button"
+              key={game}
+              onClick={() => handleToggle(game)}
+              className="flex items-center gap-1 px-3 py-1.5 bg-primary/10 text-primary hover:bg-primary/20 rounded-full transition-colors"
+              title={`Add ${getGameTypeLabel(game)}`}
+            >
+              <Plus size={14} />
+              {getGameTypeLabel(game)}
+            </button>
+          );
+        })}
+        {selectedGames.length === ALL_GAMES.length && (
+          <span className="text-xs text-muted-foreground">
+            全ての種目が選択されています
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/ui/components/setup/PlayerConfigList.tsx
+++ b/src/ui/components/setup/PlayerConfigList.tsx
@@ -1,0 +1,106 @@
+import { Cpu, Plus, Trash2, User } from "lucide-react";
+import type React from "react";
+import type { GamePlayer } from "../../../domain/types";
+
+interface Props {
+  players: GamePlayer[];
+  onChange: (players: GamePlayer[]) => void;
+}
+
+export const PlayerConfigList: React.FC<Props> = ({ players, onChange }) => {
+  const handleAddPlayer = () => {
+    if (players.length >= 7) return;
+    const newId = `p${Date.now()}`;
+    // Always add as CPU
+    onChange([
+      ...players,
+      { id: newId, name: `Player ${players.length + 1}`, kind: "cpu" },
+    ]);
+  };
+
+  const handleRemovePlayer = (id: string) => {
+    if (players.length <= 2) return;
+    onChange(players.filter((p) => p.id !== id));
+  };
+
+  const handleChange = (id: string, updates: Partial<GamePlayer>) => {
+    onChange(players.map((p) => (p.id === id ? { ...p, ...updates } : p)));
+  };
+
+  return (
+    <div className="space-y-4 p-4 border rounded-xl shadow-sm bg-card">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">
+          プレイヤー設定 ({players.length}名)
+        </h3>
+        <button
+          type="button"
+          onClick={handleAddPlayer}
+          disabled={players.length >= 7}
+          className="flex items-center gap-1 text-sm text-primary hover:bg-primary/10 px-3 py-1.5 rounded-full disabled:opacity-50 disabled:hover:bg-transparent transition-colors"
+        >
+          <Plus size={16} />
+          追加
+        </button>
+      </div>
+
+      <div className="space-y-3">
+        {players.map((player, index) => {
+          const isHuman = index === 0;
+
+          return (
+            <div
+              key={player.id}
+              className="flex items-center gap-3 p-3 bg-muted/30 rounded-lg border border-border"
+            >
+              <div className="flex-shrink-0 text-muted-foreground font-mono text-xs w-6">
+                #{index + 1}
+              </div>
+
+              <div className="flex-1">
+                <input
+                  type="text"
+                  value={player.name}
+                  onChange={(e) =>
+                    handleChange(player.id, { name: e.target.value })
+                  }
+                  className="w-full bg-background border px-3 py-1.5 rounded text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                  placeholder="Name"
+                />
+              </div>
+
+              <div className="flex items-center gap-2 px-3 py-1.5 rounded bg-muted/50 text-xs font-medium text-muted-foreground">
+                {isHuman ? (
+                  <>
+                    <User size={14} className="text-primary" />
+                    <span className="text-primary">Human</span>
+                  </>
+                ) : (
+                  <>
+                    <Cpu size={14} />
+                    <span>CPU</span>
+                  </>
+                )}
+              </div>
+
+              <button
+                type="button"
+                onClick={() => handleRemovePlayer(player.id)}
+                disabled={players.length <= 2 || isHuman}
+                className="p-2 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded disabled:opacity-30 disabled:hover:bg-transparent transition-colors"
+                title={isHuman ? "Cannot remove Human player" : "Remove"}
+              >
+                <Trash2 size={16} />
+              </button>
+            </div>
+          );
+        })}
+      </div>
+      {players.length < 2 && (
+        <p className="text-xs text-destructive">
+          最低2名のプレイヤーが必要です
+        </p>
+      )}
+    </div>
+  );
+};

--- a/src/ui/components/setup/RotationForm.tsx
+++ b/src/ui/components/setup/RotationForm.tsx
@@ -1,0 +1,35 @@
+import type React from "react";
+
+interface Props {
+  dealPerGame: number;
+  onChange: (dealPerGame: number) => void;
+}
+
+export const RotationForm: React.FC<Props> = ({ dealPerGame, onChange }) => {
+  return (
+    <div className="space-y-4 p-4 border rounded-xl shadow-sm bg-card">
+      <h3 className="text-lg font-semibold">ローテーション設定</h3>
+
+      <div className="flex items-center gap-4">
+        <label className="space-y-1 flex-1">
+          <span className="text-xs text-muted-foreground font-medium">
+            種目切り替え頻度 (Deal数)
+          </span>
+          <input
+            type="number"
+            min={1}
+            value={dealPerGame}
+            onChange={(e) => {
+              const val = parseInt(e.target.value, 10);
+              if (!Number.isNaN(val) && val >= 1) onChange(val);
+            }}
+            className="w-full bg-background border px-3 py-2 rounded text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+          />
+        </label>
+        <div className="text-xs text-muted-foreground pt-4 flex-1">
+          指定したディール数ごとに、次の種目に切り替わります。
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/ui/components/setup/StakesForm.tsx
+++ b/src/ui/components/setup/StakesForm.tsx
@@ -1,0 +1,95 @@
+import type React from "react";
+import type { Stakes } from "../../../domain/types";
+
+interface Props {
+  stakes: Stakes;
+  onChange: (stakes: Stakes) => void;
+}
+
+const PRESETS: Record<string, Stakes> = {
+  Low: { ante: 5, bringIn: 10, smallBet: 20, bigBet: 40 },
+  Mid: { ante: 10, bringIn: 20, smallBet: 40, bigBet: 80 },
+  High: { ante: 100, bringIn: 200, smallBet: 400, bigBet: 800 },
+};
+
+export const StakesForm: React.FC<Props> = ({ stakes, onChange }) => {
+  const applyPreset = (name: string) => {
+    onChange(PRESETS[name]);
+  };
+
+  const getActivePreset = (): string | null => {
+    for (const [name, preset] of Object.entries(PRESETS)) {
+      if (
+        stakes.ante === preset.ante &&
+        stakes.bringIn === preset.bringIn &&
+        stakes.smallBet === preset.smallBet &&
+        stakes.bigBet === preset.bigBet
+      ) {
+        return name;
+      }
+    }
+    return null;
+  };
+
+  const activePreset = getActivePreset();
+
+  return (
+    <div className="space-y-4 p-4 border rounded-xl shadow-sm bg-card">
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold">ステークス設定</h3>
+          <div className="flex gap-2">
+            {Object.keys(PRESETS).map((name) => {
+              const isActive = activePreset === name;
+              return (
+                <button
+                  key={name}
+                  type="button"
+                  onClick={() => applyPreset(name)}
+                  className={`px-4 py-1.5 text-sm font-medium rounded-full transition-all ${
+                    isActive
+                      ? "bg-primary text-primary-foreground shadow ring-2 ring-primary/20"
+                      : "bg-muted text-muted-foreground hover:bg-muted/80"
+                  }`}
+                >
+                  {name}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 pt-2">
+          <div className="bg-muted/30 p-2 rounded border border-border/50 text-center">
+            <div className="text-xs text-muted-foreground font-medium mb-1">
+              Ante
+            </div>
+            <div className="text-lg font-mono font-medium">{stakes.ante}</div>
+          </div>
+          <div className="bg-muted/30 p-2 rounded border border-border/50 text-center">
+            <div className="text-xs text-muted-foreground font-medium mb-1">
+              Bring-In
+            </div>
+            <div className="text-lg font-mono font-medium">
+              {stakes.bringIn}
+            </div>
+          </div>
+          <div className="bg-muted/30 p-2 rounded border border-border/50 text-center">
+            <div className="text-xs text-muted-foreground font-medium mb-1">
+              Small Bet
+            </div>
+            <div className="text-lg font-mono font-medium">
+              {stakes.smallBet}
+            </div>
+          </div>
+          <div className="bg-muted/30 p-2 rounded border border-border/50 text-center">
+            <div className="text-xs text-muted-foreground font-medium mb-1">
+              Big Bet
+            </div>
+            <div className="text-lg font-mono font-medium">{stakes.bigBet}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/ui/pages/SetupPage.tsx
+++ b/src/ui/pages/SetupPage.tsx
@@ -1,0 +1,92 @@
+import { Play } from "lucide-react";
+import type React from "react";
+import { useState } from "react";
+import { useAppStore } from "../../app/store/appStore";
+import { createInitialGameState } from "../../domain/game";
+import type { GamePlayer, GameType, Stakes } from "../../domain/types";
+import { GameTypeSelector } from "../components/setup/GameTypeSelector";
+import { PlayerConfigList } from "../components/setup/PlayerConfigList";
+import { RotationForm } from "../components/setup/RotationForm";
+import { StakesForm } from "../components/setup/StakesForm";
+
+export const SetupPage: React.FC = () => {
+  const startNewGame = useAppStore((state) => state.startNewGame);
+  const startDeal = useAppStore((state) => state.startDeal);
+
+  // --- Local State for Form ---
+  const [selectedGames, setSelectedGames] = useState<GameType[]>([
+    "studHi",
+    "razz",
+    "stud8",
+  ]);
+  const [players, setPlayers] = useState<GamePlayer[]>([
+    { id: "p1", name: "Hero", kind: "human" },
+    { id: "p2", name: "Villain", kind: "cpu" },
+  ]);
+  // Default Stakes (High limit example)
+  const [stakes, setStakes] = useState<Stakes>({
+    ante: 10,
+    bringIn: 20,
+    smallBet: 40,
+    bigBet: 80,
+  });
+  const [dealPerGame, setDealPerGame] = useState(6);
+
+  const canStart = players.length >= 2 && selectedGames.length >= 1;
+
+  const handleStartGame = () => {
+    if (!canStart) return;
+
+    // 1. Create GameState
+    const initialState = createInitialGameState(
+      players,
+      { sequence: selectedGames, dealPerGame },
+      stakes,
+    );
+
+    // 2. Initialize Store
+    startNewGame(initialState);
+
+    // 3. Start First Deal Immediately (MVP UX)
+    // Seat order is just player IDs in order (simple)
+    startDeal({
+      rngSeed: Math.random().toString(),
+      seatOrder: players.map((p) => p.id),
+    });
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-8 pb-20">
+      <header className="text-center space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Mix Poker MVP</h1>
+        <p className="text-muted-foreground">Setup your game</p>
+      </header>
+
+      <section className="space-y-6">
+        <GameTypeSelector
+          selectedGames={selectedGames}
+          onChange={setSelectedGames}
+        />
+
+        <PlayerConfigList players={players} onChange={setPlayers} />
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <StakesForm stakes={stakes} onChange={setStakes} />
+          <RotationForm dealPerGame={dealPerGame} onChange={setDealPerGame} />
+        </div>
+      </section>
+
+      <div className="flex justify-center pt-4">
+        <button
+          type="button"
+          onClick={handleStartGame}
+          disabled={!canStart}
+          className="flex items-center gap-2 px-8 py-3 bg-primary text-primary-foreground font-semibold rounded-full shadow hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-all text-lg"
+        >
+          <Play fill="currentColor" size={20} />
+          Start Game
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/ui/utils/labelHelper.ts
+++ b/src/ui/utils/labelHelper.ts
@@ -1,0 +1,11 @@
+import type { GameType } from "../../domain/types";
+
+export const GAME_TYPE_LABELS: Record<GameType, string> = {
+  studHi: "7 Card Stud",
+  razz: "Razz",
+  stud8: "Stud Hi/Lo 8-or-Better",
+};
+
+export const getGameTypeLabel = (type: GameType): string => {
+  return GAME_TYPE_LABELS[type] ?? type;
+};


### PR DESCRIPTION
### M3：SETUP画面（1日）
- プレイヤー人数（2〜7）
- human/cpu、名前、stakes、dealPerGame
- 種目選択（StudHi/Razz/Stud8）
  - MVPは **ドラッグ&ドロップを後回し**にし、最初は「↑↓ボタンで並び替え」でも可
- start → Playへ

成果物：
- `SetupPage` + store action（createNewGame/startDeal）