### PR TITLE
feat: M5 カード表示機能の実装

### DIFF
--- a/src/domain/cards/dealing.ts
+++ b/src/domain/cards/dealing.ts
@@ -1,0 +1,167 @@
+import type { Card, Deck, PlayerHand, SeatIndex } from "../types";
+
+/**
+ * 52枚のデッキを生成する
+ */
+export const createDeck = (): Deck => {
+  const suits: Card["suit"][] = ["c", "d", "h", "s"];
+  const ranks: Card["rank"][] = [
+    "A",
+    "K",
+    "Q",
+    "J",
+    "T",
+    "9",
+    "8",
+    "7",
+    "6",
+    "5",
+    "4",
+    "3",
+    "2",
+  ];
+
+  const deck: Deck = [];
+  for (const suit of suits) {
+    for (const rank of ranks) {
+      deck.push({ suit, rank });
+    }
+  }
+  return deck;
+};
+
+/**
+ * seed付き疑似乱数生成器（簡易版）
+ */
+const seededRandom = (seed: string): (() => number) => {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    const char = seed.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = hash & hash; // Convert to 32bit integer
+  }
+  let value = Math.abs(hash);
+
+  return () => {
+    value = (value * 9301 + 49297) % 233280;
+    return value / 233280;
+  };
+};
+
+/**
+ * Fisher-Yates shuffle（seed付き）
+ */
+export const shuffleDeck = (deck: Deck, seed: string): Deck => {
+  const shuffled = [...deck];
+  const random = seededRandom(seed);
+
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+
+  return shuffled;
+};
+
+/**
+ * デッキから1枚取り出す（破壊的）
+ */
+const drawCard = (deck: Deck): Card | null => {
+  return deck.shift() ?? null;
+};
+
+/**
+ * 3rd Streetのカード配布（down 2 + up 1）
+ */
+export const dealCards3rd = (
+  deck: Deck,
+  activeSeats: SeatIndex[],
+  hands: Record<SeatIndex, PlayerHand>,
+): { deck: Deck; hands: Record<SeatIndex, PlayerHand> } => {
+  const newDeck = [...deck];
+  const newHands = { ...hands };
+
+  for (const seat of activeSeats) {
+    if (!newHands[seat]) {
+      newHands[seat] = { downCards: [], upCards: [] };
+    }
+
+    // down 2枚
+    for (let i = 0; i < 2; i++) {
+      const card = drawCard(newDeck);
+      if (card) {
+        newHands[seat].downCards.push(card);
+      }
+    }
+
+    // up 1枚
+    const upCard = drawCard(newDeck);
+    if (upCard) {
+      newHands[seat].upCards.push(upCard);
+    }
+  }
+
+  return { deck: newDeck, hands: newHands };
+};
+
+/**
+ * 4th〜6th Streetのカード配布（up 1枚）
+ */
+export const dealCardUp = (
+  deck: Deck,
+  activeSeats: SeatIndex[],
+  hands: Record<SeatIndex, PlayerHand>,
+): { deck: Deck; hands: Record<SeatIndex, PlayerHand> } => {
+  const newDeck = [...deck];
+  const newHands = { ...hands };
+
+  for (const seat of activeSeats) {
+    if (!newHands[seat]) {
+      newHands[seat] = { downCards: [], upCards: [] };
+    }
+
+    const card = drawCard(newDeck);
+    if (card) {
+      newHands[seat].upCards.push(card);
+    }
+  }
+
+  return { deck: newDeck, hands: newHands };
+};
+
+/**
+ * 7th Streetのカード配布（down 1枚）
+ */
+export const dealCard7th = (
+  deck: Deck,
+  activeSeats: SeatIndex[],
+  hands: Record<SeatIndex, PlayerHand>,
+): { deck: Deck; hands: Record<SeatIndex, PlayerHand> } => {
+  const newDeck = [...deck];
+  const newHands = { ...hands };
+
+  for (const seat of activeSeats) {
+    if (!newHands[seat]) {
+      newHands[seat] = { downCards: [], upCards: [] };
+    }
+
+    const card = drawCard(newDeck);
+    if (card) {
+      newHands[seat].downCards.push(card);
+    }
+  }
+
+  return { deck: newDeck, hands: newHands };
+};
+
+/**
+ * 全カードを取得（役判定用）
+ */
+export const getAllCardsForSeat = (
+  hands: Record<SeatIndex, PlayerHand>,
+  seat: SeatIndex,
+): Card[] => {
+  const hand = hands[seat];
+  if (!hand) return [];
+  return [...hand.downCards, ...hand.upCards];
+};

--- a/src/domain/game.ts
+++ b/src/domain/game.ts
@@ -106,6 +106,9 @@ export const startNewDeal = (
     checksThisStreet: 0,
     actionsThisStreet: [],
     dealFinished: false,
+    deck: [], // DEAL_INITイベントで初期化
+    rngSeed: params.rngSeed,
+    hands: {}, // DEAL_INITイベントで初期化
   };
 
   return {

--- a/src/domain/types/index.ts
+++ b/src/domain/types/index.ts
@@ -6,6 +6,35 @@ export type PlayerKind = "human" | "cpu";
 export type EventId = string;
 export type PlayerId = string;
 
+// Card関連
+export type Suit = "c" | "d" | "h" | "s";
+export type Rank =
+  | "A"
+  | "K"
+  | "Q"
+  | "J"
+  | "T"
+  | "9"
+  | "8"
+  | "7"
+  | "6"
+  | "5"
+  | "4"
+  | "3"
+  | "2";
+
+export interface Card {
+  suit: Suit;
+  rank: Rank;
+}
+
+export type Deck = Card[];
+
+export interface PlayerHand {
+  downCards: Card[]; // 裏
+  upCards: Card[]; // 表
+}
+
 // DealState関連
 export interface PlayerState {
   seat: SeatIndex;
@@ -35,6 +64,9 @@ export interface DealState {
   checksThisStreet: number;
   actionsThisStreet: string[];
   dealFinished: boolean;
+  deck: Deck;
+  rngSeed: string;
+  hands: Record<SeatIndex, PlayerHand>;
 }
 
 // Event関連
@@ -48,7 +80,13 @@ export type EventType =
   | "FOLD"
   | "CHECK"
   | "STREET_ADVANCE"
-  | "DEAL_END";
+  | "DEAL_END"
+  | "DEAL_INIT"
+  | "DEAL_CARDS_3RD"
+  | "DEAL_CARD_4TH"
+  | "DEAL_CARD_5TH"
+  | "DEAL_CARD_6TH"
+  | "DEAL_CARD_7TH";
 
 export interface BaseEvent {
   id: EventId;
@@ -124,6 +162,25 @@ export interface DealEndEvent extends BaseEvent {
   street: Street | null;
 }
 
+export interface DealInitEvent extends BaseEvent {
+  type: "DEAL_INIT";
+  seat: null;
+  street: null;
+  rngSeed: string;
+}
+
+export interface DealCards3rdEvent extends BaseEvent {
+  type: "DEAL_CARDS_3RD";
+  seat: null;
+  street: "3rd";
+}
+
+export interface DealCardEvent extends BaseEvent {
+  type: "DEAL_CARD_4TH" | "DEAL_CARD_5TH" | "DEAL_CARD_6TH" | "DEAL_CARD_7TH";
+  seat: null;
+  street: "4th" | "5th" | "6th" | "7th";
+}
+
 export type Event =
   | PostAnteEvent
   | BringInEvent
@@ -134,7 +191,10 @@ export type Event =
   | FoldEvent
   | CheckEvent
   | StreetAdvanceEvent
-  | DealEndEvent;
+  | DealEndEvent
+  | DealInitEvent
+  | DealCards3rdEvent
+  | DealCardEvent;
 
 // GameState関連
 export interface GamePlayer {

--- a/src/ui/components/TableView/PlayerCards.tsx
+++ b/src/ui/components/TableView/PlayerCards.tsx
@@ -1,0 +1,171 @@
+import type React from "react";
+import type { Card, PlayerHand, PlayerKind } from "../../../domain/types";
+
+interface PlayerCardsProps {
+  hand: PlayerHand;
+  playerKind: PlayerKind;
+  isActive: boolean;
+}
+
+/**
+ * カードを表示するコンポーネント（裏面）
+ */
+const CardBack: React.FC = () => {
+  return (
+    <div className="w-12 h-16 bg-gradient-to-br from-blue-600 to-blue-800 rounded border-2 border-blue-900 shadow-md flex items-center justify-center">
+      <div className="text-white text-xs font-bold">?</div>
+    </div>
+  );
+};
+
+/**
+ * カードを表示するコンポーネント（表面）
+ * 重ねても見えるように左上に数字とスートを小さく表示
+ */
+const CardFront: React.FC<{ card: Card }> = ({ card }) => {
+  const suitSymbols: Record<Card["suit"], string> = {
+    c: "♣",
+    d: "♦",
+    h: "♥",
+    s: "♠",
+  };
+
+  const suitColors: Record<Card["suit"], string> = {
+    c: "text-black",
+    d: "text-red-600",
+    h: "text-red-600",
+    s: "text-black",
+  };
+
+  return (
+    <div className="relative w-12 h-16 bg-white rounded border-2 border-gray-800 shadow-md">
+      {/* 左上に数字とスートを小さく表示 */}
+      <div className="absolute top-0.5 left-0.5 flex flex-col items-start">
+        <div
+          className={`text-xs font-bold leading-tight ${suitColors[card.suit]}`}
+        >
+          {card.rank}
+        </div>
+        <div className={`text-xs leading-tight ${suitColors[card.suit]}`}>
+          {suitSymbols[card.suit]}
+        </div>
+      </div>
+      {/* 中央にも大きく表示（見やすさのため） */}
+      <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 flex flex-col items-center">
+        <div className={`text-lg font-bold ${suitColors[card.suit]}`}>
+          {card.rank}
+        </div>
+        <div className={`text-xl ${suitColors[card.suit]}`}>
+          {suitSymbols[card.suit]}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * PlayerCardsコンポーネント
+ * レイアウト：d1 d2 u1 u2 u3 u4 d3
+ * Humanはdown表示、他は裏
+ * カードは重ねて表示し、upCardsは上方向にオフセット
+ */
+export const PlayerCards: React.FC<PlayerCardsProps> = ({
+  hand,
+  playerKind,
+  isActive,
+}) => {
+  if (!isActive) {
+    return null; // foldしたプレイヤーはカードを表示しない
+  }
+
+  const isHuman = playerKind === "human";
+  const { downCards, upCards } = hand;
+
+  // レイアウト：d1 d2 u1 u2 u3 u4 d3
+  // downCards[0], downCards[1], upCards[0], upCards[1], upCards[2], upCards[3], downCards[2]
+
+  // カードの幅は48px（w-12）
+  // カードの配置: d1(0), d2(15), u1(30), u2(45), u3(60), u4(75), d3(90)
+  // 全てのカードが存在する場合、最初のカードの左端が0px、最後のカードの右端が90+48=138px
+  // SeatPanelの中心にカードの集合の中心が来るように、コンテナの幅を138pxにして中央揃え
+  const cardWidth = 48; // w-12 = 48px
+  const lastCardLeft = 90; // d3のleft位置
+  const lastCardRight = lastCardLeft + cardWidth; // 138px
+
+  return (
+    <div
+      className="relative flex items-end mt-2 mx-auto"
+      style={{ height: "64px", width: `${lastCardRight}px` }}
+    >
+      {/* d1 */}
+      {downCards[0] && (
+        <div
+          className="absolute bottom-0"
+          style={{ left: `${0}px`, zIndex: 0 }}
+        >
+          {isHuman ? <CardFront card={downCards[0]} /> : <CardBack />}
+        </div>
+      )}
+
+      {/* d2 */}
+      {downCards[1] && (
+        <div
+          className="absolute bottom-0"
+          style={{ left: `${15}px`, zIndex: 1 }}
+        >
+          {isHuman ? <CardFront card={downCards[1]} /> : <CardBack />}
+        </div>
+      )}
+
+      {/* u1 */}
+      {upCards[0] && (
+        <div
+          className="absolute"
+          style={{ left: `${30}px`, bottom: "8px", zIndex: 2 }}
+        >
+          <CardFront card={upCards[0]} />
+        </div>
+      )}
+
+      {/* u2 */}
+      {upCards[1] && (
+        <div
+          className="absolute"
+          style={{ left: `${45}px`, bottom: "8px", zIndex: 3 }}
+        >
+          <CardFront card={upCards[1]} />
+        </div>
+      )}
+
+      {/* u3 */}
+      {upCards[2] && (
+        <div
+          className="absolute"
+          style={{ left: `${60}px`, bottom: "8px", zIndex: 4 }}
+        >
+          <CardFront card={upCards[2]} />
+        </div>
+      )}
+
+      {/* u4 */}
+      {upCards[3] && (
+        <div
+          className="absolute"
+          style={{ left: `${75}px`, bottom: "8px", zIndex: 5 }}
+        >
+          <CardFront card={upCards[3]} />
+        </div>
+      )}
+
+      {/* d3 */}
+      {downCards[2] && (
+        <div
+          className="absolute bottom-0"
+          style={{ left: `${90}px`, zIndex: 6 }}
+        >
+          {isHuman ? <CardFront card={downCards[2]} /> : <CardBack />}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/ui/components/TableView/SeatPanel.tsx
+++ b/src/ui/components/TableView/SeatPanel.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
-import type { PlayerState } from "../../../domain/types";
+import type { DealState, PlayerState } from "../../../domain/types";
 import { ActiveIndicator } from "./ActiveIndicator";
+import { PlayerCards } from "./PlayerCards";
 
 interface SeatPanelProps {
   player: PlayerState;
@@ -9,6 +10,7 @@ interface SeatPanelProps {
   seatIndex: number;
   totalSeats: number;
   players: PlayerState[]; // Heroの位置を計算するために必要
+  deal: DealState; // カード情報を取得するために必要
 }
 
 export const SeatPanel: React.FC<SeatPanelProps> = ({
@@ -18,6 +20,7 @@ export const SeatPanel: React.FC<SeatPanelProps> = ({
   seatIndex,
   totalSeats,
   players,
+  deal,
 }) => {
   // Hero（Human）は常に下部中央（6時の位置）に配置
   // 他のプレイヤーは時計回りに配置
@@ -37,7 +40,8 @@ export const SeatPanel: React.FC<SeatPanelProps> = ({
     angle = 90 + (relativeIndex * 360) / totalSeats;
   }
 
-  const radius = 280; // テーブルの半径（px）- 大きくして見切れを防ぐ
+  // 半径を小さくして中心に寄せる（見切れを防ぐ）
+  const radius = 200; // テーブルの半径（px）
   const x = Math.cos((angle * Math.PI) / 180) * radius;
   const y = Math.sin((angle * Math.PI) / 180) * radius;
 
@@ -75,6 +79,11 @@ export const SeatPanel: React.FC<SeatPanelProps> = ({
               </span>
             </div>
           </div>
+          <PlayerCards
+            hand={deal.hands[player.seat] ?? { downCards: [], upCards: [] }}
+            playerKind={player.kind}
+            isActive={player.active}
+          />
         </div>
       </div>
     </div>

--- a/src/ui/components/TableView/TableView.tsx
+++ b/src/ui/components/TableView/TableView.tsx
@@ -37,6 +37,7 @@ export const TableView: React.FC<TableViewProps> = ({ deal, game }) => {
             seatIndex={index}
             totalSeats={deal.playerCount}
             players={deal.players}
+            deal={deal}
           />
         );
       })}

--- a/test/domain/cards/dealing.test.ts
+++ b/test/domain/cards/dealing.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "vitest";
+import {
+  createDeck,
+  dealCard7th,
+  dealCards3rd,
+  dealCardUp,
+  getAllCardsForSeat,
+  shuffleDeck,
+} from "../../../src/domain/cards/dealing";
+import type { Card, SeatIndex } from "../../../src/domain/types";
+
+describe("dealing", () => {
+  describe("createDeck", () => {
+    it("52枚のデッキを生成すること", () => {
+      const deck = createDeck();
+      expect(deck).toHaveLength(52);
+    });
+
+    it("重複がないこと", () => {
+      const deck = createDeck();
+      const cardStrings = deck.map((c) => `${c.suit}${c.rank}`);
+      const uniqueCards = new Set(cardStrings);
+      expect(uniqueCards.size).toBe(52);
+    });
+
+    it("全てのスートとランクが含まれること", () => {
+      const deck = createDeck();
+      const suits = new Set(deck.map((c) => c.suit));
+      const ranks = new Set(deck.map((c) => c.rank));
+
+      expect(suits.size).toBe(4);
+      expect(suits.has("c")).toBe(true);
+      expect(suits.has("d")).toBe(true);
+      expect(suits.has("h")).toBe(true);
+      expect(suits.has("s")).toBe(true);
+
+      expect(ranks.size).toBe(13);
+      const expectedRanks = [
+        "A",
+        "K",
+        "Q",
+        "J",
+        "T",
+        "9",
+        "8",
+        "7",
+        "6",
+        "5",
+        "4",
+        "3",
+        "2",
+      ];
+      expectedRanks.forEach((rank) => {
+        expect(ranks.has(rank)).toBe(true);
+      });
+    });
+  });
+
+  describe("shuffleDeck", () => {
+    it("seedにより再現可能であること", () => {
+      const deck1 = createDeck();
+      const deck2 = createDeck();
+      const seed = "test-seed-123";
+
+      const shuffled1 = shuffleDeck(deck1, seed);
+      const shuffled2 = shuffleDeck(deck2, seed);
+
+      expect(shuffled1).toEqual(shuffled2);
+    });
+
+    it("異なるseedで異なる結果になること", () => {
+      const deck1 = createDeck();
+      const deck2 = createDeck();
+
+      const shuffled1 = shuffleDeck(deck1, "seed1");
+      const shuffled2 = shuffleDeck(deck2, "seed2");
+
+      expect(shuffled1).not.toEqual(shuffled2);
+    });
+
+    it("カードの枚数が変わらないこと", () => {
+      const deck = createDeck();
+      const shuffled = shuffleDeck(deck, "test-seed");
+      expect(shuffled).toHaveLength(52);
+    });
+
+    it("全てのカードが含まれること", () => {
+      const deck = createDeck();
+      const shuffled = shuffleDeck(deck, "test-seed");
+
+      const originalCards = new Set(deck.map((c) => `${c.suit}${c.rank}`));
+      const shuffledCards = new Set(shuffled.map((c) => `${c.suit}${c.rank}`));
+
+      expect(originalCards).toEqual(shuffledCards);
+    });
+  });
+
+  describe("dealCards3rd", () => {
+    it("各active seatにdown2+up1が配られること", () => {
+      const deck = createDeck();
+      const activeSeats: SeatIndex[] = [0, 1, 2];
+      const hands: Record<SeatIndex, { downCards: Card[]; upCards: Card[] }> = {
+        0: { downCards: [], upCards: [] },
+        1: { downCards: [], upCards: [] },
+        2: { downCards: [], upCards: [] },
+      };
+
+      const result = dealCards3rd(deck, activeSeats, hands);
+
+      // 各seatにdown2+up1が配られている
+      expect(result.hands[0].downCards).toHaveLength(2);
+      expect(result.hands[0].upCards).toHaveLength(1);
+      expect(result.hands[1].downCards).toHaveLength(2);
+      expect(result.hands[1].upCards).toHaveLength(1);
+      expect(result.hands[2].downCards).toHaveLength(2);
+      expect(result.hands[2].upCards).toHaveLength(1);
+
+      // デッキから9枚消費されている（3人×3枚）
+      expect(result.deck).toHaveLength(deck.length - 9);
+    });
+
+    it("fold済みseatには配られないこと", () => {
+      const deck = createDeck();
+      const activeSeats: SeatIndex[] = [0, 2]; // seat 1はfold済み
+      const hands: Record<SeatIndex, { downCards: Card[]; upCards: Card[] }> = {
+        0: { downCards: [], upCards: [] },
+        1: { downCards: [], upCards: [] }, // fold済み
+        2: { downCards: [], upCards: [] },
+      };
+
+      const result = dealCards3rd(deck, activeSeats, hands);
+
+      expect(result.hands[0].downCards).toHaveLength(2);
+      expect(result.hands[0].upCards).toHaveLength(1);
+      expect(result.hands[1].downCards).toHaveLength(0); // fold済みなので配られない
+      expect(result.hands[1].upCards).toHaveLength(0);
+      expect(result.hands[2].downCards).toHaveLength(2);
+      expect(result.hands[2].upCards).toHaveLength(1);
+    });
+  });
+
+  describe("dealCardUp", () => {
+    it("各active seatにup1枚が配られること", () => {
+      const deck = createDeck();
+      const activeSeats: SeatIndex[] = [0, 1];
+      const hands: Record<SeatIndex, { downCards: Card[]; upCards: Card[] }> = {
+        0: { downCards: [], upCards: [] },
+        1: { downCards: [], upCards: [] },
+      };
+
+      const result = dealCardUp(deck, activeSeats, hands);
+
+      expect(result.hands[0].upCards).toHaveLength(1);
+      expect(result.hands[1].upCards).toHaveLength(1);
+      expect(result.deck).toHaveLength(deck.length - 2);
+    });
+
+    it("既存のupCardsに追加されること", () => {
+      const deck = createDeck();
+      const activeSeats: SeatIndex[] = [0];
+      const hands: Record<SeatIndex, { downCards: Card[]; upCards: Card[] }> = {
+        0: {
+          downCards: [],
+          upCards: [{ suit: "c", rank: "A" }], // 既存のカード
+        },
+      };
+
+      const result = dealCardUp(deck, activeSeats, hands);
+
+      expect(result.hands[0].upCards).toHaveLength(2); // 既存1枚 + 新規1枚
+    });
+  });
+
+  describe("dealCard7th", () => {
+    it("各active seatにdown1枚が配られること", () => {
+      const deck = createDeck();
+      const activeSeats: SeatIndex[] = [0, 1];
+      const hands: Record<SeatIndex, { downCards: Card[]; upCards: Card[] }> = {
+        0: { downCards: [], upCards: [] },
+        1: { downCards: [], upCards: [] },
+      };
+
+      const result = dealCard7th(deck, activeSeats, hands);
+
+      expect(result.hands[0].downCards).toHaveLength(1);
+      expect(result.hands[1].downCards).toHaveLength(1);
+      expect(result.deck).toHaveLength(deck.length - 2);
+    });
+
+    it("既存のdownCardsに追加されること", () => {
+      const deck = createDeck();
+      const activeSeats: SeatIndex[] = [0];
+      const hands: Record<SeatIndex, { downCards: Card[]; upCards: Card[] }> = {
+        0: {
+          downCards: [
+            { suit: "c", rank: "A" },
+            { suit: "d", rank: "K" },
+          ], // 既存2枚
+          upCards: [],
+        },
+      };
+
+      const result = dealCard7th(deck, activeSeats, hands);
+
+      expect(result.hands[0].downCards).toHaveLength(3); // 既存2枚 + 新規1枚
+    });
+  });
+
+  describe("getAllCardsForSeat", () => {
+    it("downCardsとupCardsを結合して返すこと", () => {
+      const hands: Record<SeatIndex, { downCards: Card[]; upCards: Card[] }> = {
+        0: {
+          downCards: [
+            { suit: "c", rank: "A" },
+            { suit: "d", rank: "K" },
+          ],
+          upCards: [
+            { suit: "h", rank: "Q" },
+            { suit: "s", rank: "J" },
+          ],
+        },
+      };
+
+      const allCards = getAllCardsForSeat(hands, 0);
+      expect(allCards).toHaveLength(4);
+      expect(allCards[0]).toEqual({ suit: "c", rank: "A" });
+      expect(allCards[1]).toEqual({ suit: "d", rank: "K" });
+      expect(allCards[2]).toEqual({ suit: "h", rank: "Q" });
+      expect(allCards[3]).toEqual({ suit: "s", rank: "J" });
+    });
+
+    it("handが存在しない場合は空配列を返すこと", () => {
+      const hands: Record<SeatIndex, { downCards: Card[]; upCards: Card[] }> =
+        {};
+
+      const allCards = getAllCardsForSeat(hands, 0);
+      expect(allCards).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
### M5：カード表示（MVP範囲）（1〜2日）
- PlayerCards
  - レイアウト：`d1 d2 u1 u2 u3 u4 d3`
  - Humanはdown表示、他は裏
- DEAL_CARDS_* イベント（既存イベント設計に合わせる）

※ 「カード配布設計書」の採番は、このタイミングで確定させる（後述）


- Card型、Deck型、PlayerHand型を追加
- DealStateにdeck、rngSeed、handsフィールドを追加
- DEAL_INIT、DEAL_CARDS_3RD、DEAL_CARD_4TH〜7THイベント型を追加
- dealing.tsでカード配布ロジックを実装（createDeck、shuffleDeck、dealCards3rd、dealCardUp、dealCard7th）
- applyEventにカード配布イベントのハンドラーを追加
- startDealでDEAL_INIT → POST_ANTE → DEAL_CARDS_3RDを発火
- STREET_ADVANCE後にカード配布イベントを自動発火
- PlayerCardsコンポーネントを作成（レイアウト：d1 d2 u1 u2 u3 u4 d3）
- カードを重ねて表示し、upCardsを上方向にオフセット
- カードの数字とスートを左上に小さく表示
- SeatPanelにPlayerCardsを統合し、中央揃えに調整
- カード配布ロジックとイベントハンドラーの単体テストを追加