### PR TITLE
#25 docs: READMEをプロジェクト固有の内容に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,112 @@
-# React + TypeScript + Vite
+# Mix Poker
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+ポーカーのMixゲーム（Stud系）をCPU対戦で遊べるWebアプリケーションです。
 
-Currently, two official plugins are available:
+## 概要
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+Mix Pokerは、フロントエンド完結型のポーカーゲームアプリです。人間プレイヤーとCPUプレイヤーが対戦でき、Stud系の3種目（Stud Hi / Razz / Stud8）をプレイできます。
 
-## React Compiler
+## 主な機能
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+- **CPU対戦**: 人間プレイヤー vs CPU（1〜6人）の対戦
+- **複数種目対応**: Stud Hi、Razz、Stud8の3種目に対応
+- **Mixゲーム**: 複数の種目を順番にプレイ可能
+- **履歴保存**: ハンド履歴をlocalStorageに保存（最大200件、直近10件はフル保存）
+- **ルール準拠**: 正しいポーカールールに基づいたゲーム進行
 
-## Expanding the ESLint configuration
+## 技術スタック
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+- **フレームワーク**: React 19 + TypeScript
+- **ビルドツール**: Vite
+- **状態管理**: Zustand
+- **スタイリング**: Tailwind CSS
+- **テスト**: Vitest
+- **フォーマッタ**: Biome
+- **その他**: Immer, Zod, pokersolver
 
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
+## セットアップ
 
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
+### 必要な環境
 
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+- Node.js (推奨バージョン: 18以上)
+- npm または yarn
+
+### インストール
+
+```bash
+npm install
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+### 開発サーバーの起動
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm run dev
 ```
+
+ブラウザで `http://localhost:5173` を開いてください。
+
+### ビルド
+
+```bash
+npm run build
+```
+
+### プレビュー
+
+```bash
+npm run preview
+```
+
+## 開発コマンド
+
+```bash
+# テスト実行
+npm test
+
+# テストをウォッチモードで実行
+npm run test:watch
+
+# リントチェック
+npm run lint
+
+# リント自動修正
+npm run lint:fix
+
+# フォーマット
+npm run format
+```
+
+## プロジェクト構造
+
+```
+src/
+├── app/              # アプリケーション層（ストア、型定義）
+├── domain/           # ドメイン層（ゲームロジック、ルール、エンジン）
+│   ├── cards/        # カード配布
+│   ├── cpu/          # CPU意思決定ロジック
+│   ├── engine/       # イベント適用エンジン
+│   ├── rules/        # ルール判定
+│   ├── showdown/     # ショーダウン処理
+│   └── types/        # ドメイン型定義
+└── ui/               # UI層（コンポーネント、ページ）
+    ├── components/   # 再利用可能なコンポーネント
+    ├── pages/        # ページコンポーネント
+    └── utils/        # UIユーティリティ
+
+docs/                 # 設計ドキュメント
+test/                 # テストファイル
+```
+
+## ドキュメント
+
+詳細な設計ドキュメントは [`docs/mvp/`](./docs/mvp/) を参照してください。
+
+- [MVP定義書](./docs/mvp/01_MVP定義書.md)
+- [ルール仕様書](./docs/mvp/02_ルール仕様書.md)
+- [状態設計書](./docs/mvp/03_状態設計書.md)
+- [イベント設計書](./docs/mvp/04_イベント設計書.md)
+- その他の設計書は [`docs/mvp/README.md`](./docs/mvp/README.md) を参照
+
+## ライセンス
+
+このプロジェクトはプライベートプロジェクトです。


### PR DESCRIPTION
## 目的
デフォルトのViteテンプレートのREADMEを、Mix Pokerプロジェクト固有の内容に更新する。

## 変更内容
- プロジェクトの概要と目的を追加
- 主な機能（CPU対戦、複数種目対応、履歴保存など）を記載
- 技術スタックの一覧を追加
- セットアップ手順と開発コマンドを記載
- プロジェクト構造の説明を追加
- 設計ドキュメントへのリンクを追加

## チェックリスト
- [x] 実装完了
- [x] Lint/Format通過
- [x] テスト通過（128テストすべて通過）
- [x] コミット・プッシュ完了

## 関連Issue
Closes #25