### PR TITLE
chore: MCPサーバーの環境変数名をGITHUB_TOKENに変更

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-github"],
       "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+        "GITHUB_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
       }
     }
   }


### PR DESCRIPTION
## 目的
GitHub MCPサーバーが正しく動作するように、環境変数名を修正する。

## 変更内容
- `.cursor/mcp.json` の環境変数名を `GITHUB_PERSONAL_ACCESS_TOKEN` から `GITHUB_TOKEN` に変更
- GitHub MCPサーバーが期待する環境変数名に合わせて修正

## 背景
GitHub MCPサーバーは `GITHUB_TOKEN` という環境変数名を期待しているため、設定ファイルを修正。

## チェックリスト
- [x] 変更内容の確認
- [x] コミット・プッシュ完了