### PR TITLE
feat: ショーダウン時に各プレイヤーのHigh役を表示 (#31)

### DIFF
--- a/src/ui/components/TableView/SeatPanel.tsx
+++ b/src/ui/components/TableView/SeatPanel.tsx
@@ -15,6 +15,7 @@ interface SeatPanelProps {
   isDealFinished: boolean; // ディールが終了しているかどうか
   isWinner?: boolean; // 勝者かどうか
   winningsAmount?: number | null; // 獲得額（正の値のみ）
+  handRankLabel?: string | null; // 役の日本語ラベル
 }
 
 export const SeatPanel: React.FC<SeatPanelProps> = ({
@@ -28,6 +29,7 @@ export const SeatPanel: React.FC<SeatPanelProps> = ({
   isDealFinished,
   isWinner = false,
   winningsAmount = null,
+  handRankLabel = null,
 }) => {
   // Hero（Human）は常に下部中央（6時の位置）に配置
   // 他のプレイヤーは時計回りに配置
@@ -90,6 +92,11 @@ export const SeatPanel: React.FC<SeatPanelProps> = ({
               <div className="text-xs font-bold text-yellow-400">WINNER</div>
             )}
           </div>
+          {isDealFinished && player.active && handRankLabel && (
+            <div className="text-xs font-semibold text-blue-400">
+              {handRankLabel}
+            </div>
+          )}
           {!player.active && (
             <div className="text-xs text-destructive font-semibold">FOLDED</div>
           )}

--- a/src/ui/utils/handRankLabel.ts
+++ b/src/ui/utils/handRankLabel.ts
@@ -1,0 +1,19 @@
+import type { HandRank } from "../../domain/types";
+
+/**
+ * HandRankを日本語ラベルに変換する
+ */
+const HAND_RANK_LABELS: Record<HandRank, string> = {
+  HIGH_CARD: "ハイカード",
+  ONE_PAIR: "ワンペア",
+  TWO_PAIR: "ツーペア",
+  THREE_OF_A_KIND: "スリーカード",
+  STRAIGHT: "ストレート",
+  FLUSH: "フラッシュ",
+  FULL_HOUSE: "フルハウス",
+  FOUR_OF_A_KIND: "フォーカード",
+  STRAIGHT_FLUSH: "ストレートフラッシュ",
+};
+
+export const getHandRankLabel = (rank: HandRank): string =>
+  HAND_RANK_LABELS[rank];


### PR DESCRIPTION
## 概要
ショーダウン時に各プレイヤーのHigh役を日本語で表示する機能を追加しました。

## 変更内容
- **新規ファイル**: `src/ui/utils/handRankLabel.ts`
  - `HandRank`型を日本語ラベルに変換するユーティリティ関数
  - 例：ONE_PAIR → "ワンペア", FLUSH → "フラッシュ"

- **修正ファイル**: `src/ui/components/TableView/TableView.tsx`
  - `dealFinished`時に各アクティブプレイヤーの役を計算
  - `SeatPanel`に`handRankLabel`を渡す

- **修正ファイル**: `src/ui/components/TableView/SeatPanel.tsx`
  - `handRankLabel` propsを追加
  - ショーダウン時にアクティブプレイヤーの役を青色で表示

## テスト結果
- ✅ Lint/Format通過
- ✅ ブラウザ動作確認完了（ショーダウン画面で「ワンペア」「ツーペア」等が正しく表示される）

## 今後の対応
Low側の役表示（Razz/Stud8用）は別Issueで対応予定

Closes #31