### PR TITLE
feat: ショーダウン時にLow役を表示する機能を追加 (#33)

### DIFF
--- a/src/ui/components/TableView/SeatPanel.tsx
+++ b/src/ui/components/TableView/SeatPanel.tsx
@@ -15,7 +15,8 @@ interface SeatPanelProps {
   isDealFinished: boolean; // ディールが終了しているかどうか
   isWinner?: boolean; // 勝者かどうか
   winningsAmount?: number | null; // 獲得額（正の値のみ）
-  handRankLabel?: string | null; // 役の日本語ラベル
+  handRankLabel?: string | null; // High役の日本語ラベル
+  lowRankLabel?: string | null; // Low役のラベル
 }
 
 export const SeatPanel: React.FC<SeatPanelProps> = ({
@@ -30,6 +31,7 @@ export const SeatPanel: React.FC<SeatPanelProps> = ({
   isWinner = false,
   winningsAmount = null,
   handRankLabel = null,
+  lowRankLabel = null,
 }) => {
   // Hero（Human）は常に下部中央（6時の位置）に配置
   // 他のプレイヤーは時計回りに配置
@@ -94,7 +96,16 @@ export const SeatPanel: React.FC<SeatPanelProps> = ({
           </div>
           {isDealFinished && player.active && handRankLabel && (
             <div className="text-xs font-semibold text-blue-400">
-              {handRankLabel}
+              High: {handRankLabel}
+            </div>
+          )}
+          {isDealFinished && player.active && lowRankLabel && (
+            <div
+              className={`text-xs font-semibold ${
+                lowRankLabel === "ローなし" ? "text-gray-400" : "text-green-400"
+              }`}
+            >
+              Low: {lowRankLabel}
             </div>
           )}
           {!player.active && (

--- a/src/ui/utils/handRankLabel.ts
+++ b/src/ui/utils/handRankLabel.ts
@@ -1,4 +1,4 @@
-import type { HandRank } from "../../domain/types";
+import type { HandRank, LowHandScore } from "../../domain/types";
 
 /**
  * HandRankを日本語ラベルに変換する
@@ -17,3 +17,24 @@ const HAND_RANK_LABELS: Record<HandRank, string> = {
 
 export const getHandRankLabel = (rank: HandRank): string =>
   HAND_RANK_LABELS[rank];
+
+/**
+ * ランク数値をカード表記に変換
+ */
+const rankToChar = (rank: number): string => {
+  if (rank === 1) return "A";
+  if (rank === 10) return "T";
+  if (rank === 11) return "J";
+  if (rank === 12) return "Q";
+  if (rank === 13) return "K";
+  return String(rank);
+};
+
+/**
+ * LowHandScoreを表示文字列に変換（例: "7-5-3-2-A"）
+ */
+export const getLowHandLabel = (lowScore: LowHandScore): string => {
+  // 降順にソートして表示
+  const sorted = [...lowScore.ranks].sort((a, b) => b - a);
+  return sorted.map(rankToChar).join("-");
+};


### PR DESCRIPTION
## 概要
ショーダウン時に各プレイヤーのLow役を表示する機能を追加しました。

## 変更内容
- **修正ファイル**: `src/ui/utils/handRankLabel.ts`
  - `getLowHandLabel`関数を追加（LowHandScoreを表示文字列に変換）
  - 例: [1,2,3,4,5] → "5-4-3-2-A"

- **修正ファイル**: `src/ui/components/TableView/TableView.tsx`
  - Razz/Stud8に対応した役計算ロジックを追加
  - Stud8でLow不成立時は「ローなし」を設定

- **修正ファイル**: `src/ui/components/TableView/SeatPanel.tsx`
  - `lowRankLabel` propsを追加
  - Low役表示UI（成立時は緑色、不成立時はグレー色）

## ゲームタイプ別の表示
| ゲームタイプ | 表示内容 |
|-------------|---------|
| StudHi | High役のみ |
| Razz | Low役のみ |
| Stud8 | High役 + Low役（不成立時は「ローなし」） |

## テスト結果
- ✅ Lint/Format通過
- ✅ Razz動作確認完了（Low役が正しく表示される）
- ✅ Stud8動作確認完了（High/Low両方表示、Low不成立時はグレーで「ローなし」表示）

Closes #33