### PR TITLE
fix: リロード時に「Waiting for CPU...」でゲームがスタックするバグを修正

### DIFF
--- a/src/app/store/appStore.ts
+++ b/src/app/store/appStore.ts
@@ -94,6 +94,17 @@ const storeCreator = (set: any, get: any): AppStore => ({
         set({ lastLoadError: "Version mismatch, state reset." });
       } else {
         set(loaded);
+        // 復元後、CPUターンを再開
+        const state = get();
+        if (state.game?.currentDeal && !state.game.currentDeal.dealFinished) {
+          const currentActor =
+            state.game.currentDeal.players[
+              state.game.currentDeal.currentActorIndex
+            ];
+          if (currentActor?.kind === "cpu") {
+            setTimeout(() => get().processCpuTurns(), 500);
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
## 概要

ゲームのプレイ中にブラウザをリロードすると、CPUのターンで「Waiting for CPU...」と表示されたままゲームがスタックするバグを修正しました。

## 原因

`appStore.ts`の`initialize()`関数でlocalStorageから状態を復元した後、CPUターンを再開する`processCpuTurns()`が呼ばれていなかったため、CPUのターンでゲームが進行しなくなっていました。

## 変更内容

`initialize()`関数に、状態復元後にCPUターンを再開するロジックを追加：

```typescript
// 復元後、CPUターンを再開
const state = get();
if (state.game?.currentDeal && !state.game.currentDeal.dealFinished) {
  const currentActor =
    state.game.currentDeal.players[state.game.currentDeal.currentActorIndex];
  if (currentActor?.kind === "cpu") {
    setTimeout(() => get().processCpuTurns(), 500);
  }
}
```

## 検証

- ✅ リロード後、CPUターンが自動的に再開されることを確認
- ✅ Lint/Format通過
- ✅ テスト全128件通過

Closes #35