### PR TITLE
fix: Hero fold時およびフ7th全員check時のゲーム進行停止を修正

### DIFF
--- a/src/app/store/appStore.ts
+++ b/src/app/store/appStore.ts
@@ -185,61 +185,59 @@ const storeCreator = (set: any, get: any): AppStore => ({
         const nextDeal = applyEvent(state.game.currentDeal, event);
         state.game.currentDeal = nextDeal;
 
-        // ストリート終了判定
+        // ストリート終了判定（STREET_ADVANCEのみここで処理、DEAL_ENDは外部で処理）
         const endEvent = checkStreetEndCondition(nextDeal);
-        if (endEvent) {
+        if (endEvent && endEvent.type === "STREET_ADVANCE") {
           const afterEndDeal = applyEvent(nextDeal, endEvent);
           state.game.currentDeal = afterEndDeal;
 
           // STREET_ADVANCEの場合は次のストリートのカード配布イベントを発火
-          if (endEvent.type === "STREET_ADVANCE") {
-            const nextStreet = afterEndDeal.street;
-            let dealCardEvent: DealCardEvent | null = null;
+          const nextStreet = afterEndDeal.street;
+          let dealCardEvent: DealCardEvent | null = null;
 
-            switch (nextStreet) {
-              case "4th":
-                dealCardEvent = {
-                  id: generateId(),
-                  type: "DEAL_CARD_4TH",
-                  seat: null,
-                  street: "4th",
-                  timestamp: Date.now(),
-                };
-                break;
-              case "5th":
-                dealCardEvent = {
-                  id: generateId(),
-                  type: "DEAL_CARD_5TH",
-                  seat: null,
-                  street: "5th",
-                  timestamp: Date.now(),
-                };
-                break;
-              case "6th":
-                dealCardEvent = {
-                  id: generateId(),
-                  type: "DEAL_CARD_6TH",
-                  seat: null,
-                  street: "6th",
-                  timestamp: Date.now(),
-                };
-                break;
-              case "7th":
-                dealCardEvent = {
-                  id: generateId(),
-                  type: "DEAL_CARD_7TH",
-                  seat: null,
-                  street: "7th",
-                  timestamp: Date.now(),
-                };
-                break;
-            }
+          switch (nextStreet) {
+            case "4th":
+              dealCardEvent = {
+                id: generateId(),
+                type: "DEAL_CARD_4TH",
+                seat: null,
+                street: "4th",
+                timestamp: Date.now(),
+              };
+              break;
+            case "5th":
+              dealCardEvent = {
+                id: generateId(),
+                type: "DEAL_CARD_5TH",
+                seat: null,
+                street: "5th",
+                timestamp: Date.now(),
+              };
+              break;
+            case "6th":
+              dealCardEvent = {
+                id: generateId(),
+                type: "DEAL_CARD_6TH",
+                seat: null,
+                street: "6th",
+                timestamp: Date.now(),
+              };
+              break;
+            case "7th":
+              dealCardEvent = {
+                id: generateId(),
+                type: "DEAL_CARD_7TH",
+                seat: null,
+                street: "7th",
+                timestamp: Date.now(),
+              };
+              break;
+          }
 
-            if (dealCardEvent) {
-              // カード配布イベントを適用
-              const afterDeal = applyEvent(afterEndDeal, dealCardEvent);
-              state.game.currentDeal = afterDeal;
-            }
+          if (dealCardEvent) {
+            // カード配布イベントを適用
+            const afterDeal = applyEvent(afterEndDeal, dealCardEvent);
+            state.game.currentDeal = afterDeal;
           }
         }
       }),

--- a/src/domain/engine/applyEvent.ts
+++ b/src/domain/engine/applyEvent.ts
@@ -165,12 +165,8 @@ const handleFold = (draft: Draft<DealState>, event: FoldEvent) => {
     draft.pendingResponseCount -= 1;
   }
   // checkフェーズ（currentBet === 0）の場合はchecksThisStreetは増やさない
-
-  // 1人しか残っていないかチェック
-  const activeCount = draft.players.filter((p) => p.active).length;
-  if (activeCount <= 1) {
-    draft.dealFinished = true;
-  }
+  // 注意: dealFinishedはcheckStreetEndCondition経由で設定される
+  // applyEvent単体ではdealFinishedを設定しない（終了判定の一本化）
 };
 
 const handleCheck = (draft: Draft<DealState>, _event: CheckEvent) => {

--- a/test/domain/street.test.ts
+++ b/test/domain/street.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+import { checkStreetEndCondition } from "../../src/domain/rules/street";
+import type { DealState } from "../../src/domain/types";
+
+describe("checkStreetEndCondition", () => {
+  const createBaseDealState = (
+    overrides: Partial<DealState> = {},
+  ): DealState => ({
+    dealId: "test-deal",
+    gameType: "studHi",
+    playerCount: 2,
+    players: [
+      {
+        seat: 0,
+        kind: "human",
+        active: true,
+        stack: 1000,
+        committedTotal: 0,
+        committedThisStreet: 0,
+      },
+      {
+        seat: 1,
+        kind: "cpu",
+        active: true,
+        stack: 1000,
+        committedTotal: 0,
+        committedThisStreet: 0,
+      },
+    ],
+    seatOrder: ["player1", "player2"],
+    ante: 10,
+    bringIn: 20,
+    smallBet: 40,
+    bigBet: 80,
+    street: "3rd",
+    bringInIndex: 0,
+    currentActorIndex: 0,
+    pot: 0,
+    currentBet: 0,
+    raiseCount: 0,
+    pendingResponseCount: 0,
+    checksThisStreet: 0,
+    actionsThisStreet: [],
+    dealFinished: false,
+    deck: [],
+    rngSeed: "",
+    hands: {},
+    ...overrides,
+  });
+
+  describe("dealFinished時", () => {
+    it("dealFinishedがtrueの場合はnullを返すこと", () => {
+      const state = createBaseDealState({ dealFinished: true });
+      const result = checkStreetEndCondition(state);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("全員fold（activeが1人以下）", () => {
+    it("active playerが1人の場合、DEAL_ENDを返すこと", () => {
+      const state = createBaseDealState({
+        players: [
+          {
+            seat: 0,
+            kind: "human",
+            active: false, // fold済み
+            stack: 1000,
+            committedTotal: 10,
+            committedThisStreet: 0,
+          },
+          {
+            seat: 1,
+            kind: "cpu",
+            active: true, // 勝者
+            stack: 1000,
+            committedTotal: 30,
+            committedThisStreet: 20,
+          },
+        ],
+      });
+
+      const result = checkStreetEndCondition(state);
+
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe("DEAL_END");
+      expect(result?.seat).toBe(1); // 勝者のseat
+    });
+
+    it("active playerが0人の場合もDEAL_ENDを返すこと", () => {
+      const state = createBaseDealState({
+        players: [
+          {
+            seat: 0,
+            kind: "human",
+            active: false,
+            stack: 1000,
+            committedTotal: 10,
+            committedThisStreet: 0,
+          },
+          {
+            seat: 1,
+            kind: "cpu",
+            active: false,
+            stack: 1000,
+            committedTotal: 30,
+            committedThisStreet: 20,
+          },
+        ],
+      });
+
+      const result = checkStreetEndCondition(state);
+
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe("DEAL_END");
+      expect(result?.seat).toBeNull(); // 勝者がいない場合
+    });
+  });
+
+  describe("7th street終了時", () => {
+    it("7thで攻撃フェーズ終了時（currentBet > 0, pendingResponseCount === 0）はDEAL_ENDを返すこと", () => {
+      const state = createBaseDealState({
+        street: "7th",
+        currentBet: 80,
+        pendingResponseCount: 0,
+      });
+
+      const result = checkStreetEndCondition(state);
+
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe("DEAL_END");
+      expect(result?.street).toBe("7th");
+    });
+
+    it("7thで全員check時（currentBet === 0, checksThisStreet === activeCount）はDEAL_ENDを返すこと", () => {
+      const state = createBaseDealState({
+        street: "7th",
+        currentBet: 0,
+        checksThisStreet: 2, // 2人がcheck
+      });
+
+      const result = checkStreetEndCondition(state);
+
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe("DEAL_END");
+      expect(result?.street).toBe("7th");
+    });
+
+    it("7thでまだアクションが残っている場合はnullを返すこと", () => {
+      const state = createBaseDealState({
+        street: "7th",
+        currentBet: 0,
+        checksThisStreet: 1, // 1人しかcheckしていない
+      });
+
+      const result = checkStreetEndCondition(state);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("STREET_ADVANCE判定（7th以外）", () => {
+    it("3rdで攻撃フェーズ終了時はSTREET_ADVANCEを返すこと", () => {
+      const state = createBaseDealState({
+        street: "3rd",
+        currentBet: 40,
+        pendingResponseCount: 0,
+      });
+
+      const result = checkStreetEndCondition(state);
+
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe("STREET_ADVANCE");
+      expect(result?.street).toBe("3rd");
+    });
+
+    it("4thで全員check時はSTREET_ADVANCEを返すこと", () => {
+      const state = createBaseDealState({
+        street: "4th",
+        currentBet: 0,
+        checksThisStreet: 2,
+      });
+
+      const result = checkStreetEndCondition(state);
+
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe("STREET_ADVANCE");
+      expect(result?.street).toBe("4th");
+    });
+
+    it("ストリート途中（pendingResponseCount > 0）はnullを返すこと", () => {
+      const state = createBaseDealState({
+        street: "3rd",
+        currentBet: 40,
+        pendingResponseCount: 1, // まだ1人が反応していない
+      });
+
+      const result = checkStreetEndCondition(state);
+
+      expect(result).toBeNull();
+    });
+
+    it("checkフェーズ途中はnullを返すこと", () => {
+      const state = createBaseDealState({
+        street: "5th",
+        currentBet: 0,
+        checksThisStreet: 1, // 1人しかcheckしていない
+      });
+
+      const result = checkStreetEndCondition(state);
+
+      expect(result).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## 概要
ゲーム進行が停止する既知の不具合を修正しました。

### 問題
1. **Hero がfoldしてCPUの勝利時** - ゲームが進行しなくなる
2. **7thで全員checkだった時** - DEAL_ENDが発火されずショーダウンに進まない

### 原因
- `handleFold`関数内で`dealFinished = true`を設定していたため、後続の`checkStreetEndCondition()`がnullを返し、`finishDeal()`が実行されなかった
- `dispatch()`内のproduce()でDEAL_ENDイベントを適用してしまい、外部で再度`checkStreetEndCondition()`を呼んだ際にnullが返されていた

### 修正内容
- `handleFold`から`dealFinished = true`の設定を削除
- 終了条件判定を`checkStreetEndCondition`に一本化
- `dispatch()`内ではSTREET_ADVANCEのみproduce内で処理し、DEAL_ENDは外部ロジックで処理

### テスト
- `street.test.ts`を新規作成（`checkStreetEndCondition`の10テスト）
- `engine.test.ts`にFOLDテストを2件追加
- 全140テスト通過

Closes #37