### PR TITLE
feat: アクション履歴表示機能を実装 #44

### DIFF
--- a/src/domain/engine/applyEvent.ts
+++ b/src/domain/engine/applyEvent.ts
@@ -33,6 +33,12 @@ import type {
  */
 export const applyEvent = (state: DealState, event: Event): DealState => {
   return produce(state, (draft) => {
+    // イベントログに追加（eventLogがない場合は初期化）
+    if (!draft.eventLog) {
+      draft.eventLog = [];
+    }
+    draft.eventLog.push(event);
+
     switch (event.type) {
       case "POST_ANTE":
         handlePostAnte(draft, event);

--- a/src/domain/game.ts
+++ b/src/domain/game.ts
@@ -119,6 +119,7 @@ export const startNewDeal = (
     rngSeed: params.rngSeed,
     hands: {}, // DEAL_INITイベントで初期化
     startedAt,
+    eventLog: [], // イベントログを初期化
   };
 
   return {

--- a/src/domain/types/index.ts
+++ b/src/domain/types/index.ts
@@ -85,6 +85,7 @@ export interface DealState {
   rngSeed: string;
   hands: Record<SeatIndex, PlayerHand>;
   startedAt?: number; // ディール開始時刻（DealSummary生成用）
+  eventLog: Event[]; // Deal全体を通したイベントログ
 }
 
 // Event関連

--- a/src/ui/components/TableView/ActionHistoryPanel.tsx
+++ b/src/ui/components/TableView/ActionHistoryPanel.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef } from "react";
+import type {
+  Event,
+  GamePlayer,
+  PlayerId,
+  Street,
+} from "../../../domain/types";
+import { getActionLabel, PLAYER_ACTION_TYPES } from "../../utils/actionLabel";
+
+interface ActionHistoryPanelProps {
+  eventLog: Event[];
+  seatOrder: PlayerId[];
+  players: GamePlayer[];
+}
+
+// ストリートの日本語ラベル
+const STREET_LABELS: Record<Street, string> = {
+  "3rd": "3rd",
+  "4th": "4th",
+  "5th": "5th",
+  "6th": "6th",
+  "7th": "7th",
+};
+
+/**
+ * プレイヤーのアクション履歴を表示するパネル
+ * TableViewの左上に配置される
+ */
+export const ActionHistoryPanel: React.FC<ActionHistoryPanelProps> = ({
+  eventLog,
+  seatOrder,
+  players,
+}) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // プレイヤーアクションのみをフィルタリング（eventLogがない場合は空配列）
+  const playerActions = (eventLog ?? []).filter((event) =>
+    PLAYER_ACTION_TYPES.includes(
+      event.type as (typeof PLAYER_ACTION_TYPES)[number],
+    ),
+  );
+
+  // ストリートごとにグルーピング
+  const actionsByStreet = playerActions.reduce(
+    (acc, event) => {
+      const street = event.street ?? "3rd";
+      if (!acc[street]) {
+        acc[street] = [];
+      }
+      acc[street].push(event);
+      return acc;
+    },
+    {} as Record<Street, Event[]>,
+  );
+
+  // ストリートの順序
+  const streetOrder: Street[] = ["3rd", "4th", "5th", "6th", "7th"];
+  const activeStreets = streetOrder.filter(
+    (s) => actionsByStreet[s]?.length > 0,
+  );
+
+  // 新しいアクションがあったら自動スクロール
+  // biome-ignore lint/correctness/useExhaustiveDependencies: playerActions.lengthはeventLogから派生するため、eventLog?.lengthで十分
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [eventLog?.length]);
+
+  // seatIndexからプレイヤー名を取得
+  const getPlayerName = (seatIndex: number): string => {
+    const playerId = seatOrder[seatIndex];
+    if (!playerId) return `Seat ${seatIndex + 1}`;
+    const player = players.find((p) => p.id === playerId);
+    return player?.name ?? `Player ${seatIndex + 1}`;
+  };
+
+  // アクションから金額を取得（存在する場合）
+  const getAmount = (event: Event): number | null => {
+    if ("amount" in event) {
+      return event.amount;
+    }
+    return null;
+  };
+
+  if (playerActions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="absolute top-4 left-4 z-20 w-56 max-h-52 rounded-lg border border-white/20 bg-black/60 backdrop-blur-sm shadow-lg">
+      <div className="px-3 py-2 border-b border-white/10">
+        <h3 className="text-xs font-semibold text-white/80">アクション履歴</h3>
+      </div>
+      <div
+        ref={scrollRef}
+        className="overflow-y-auto max-h-40 p-2 scrollbar-thin scrollbar-thumb-white/20 scrollbar-track-transparent"
+      >
+        {activeStreets.map((street, streetIndex) => (
+          <div key={street} className={streetIndex > 0 ? "mt-2" : ""}>
+            {/* ストリートヘッダー */}
+            <div className="text-[10px] font-semibold text-blue-400/80 mb-1 pb-0.5 border-b border-white/10">
+              {STREET_LABELS[street]}
+            </div>
+            {/* そのストリートのアクション */}
+            <div className="space-y-0.5">
+              {actionsByStreet[street].map((event, index) => {
+                const seatIndex = event.seat;
+                if (seatIndex === null) return null;
+
+                const playerName = getPlayerName(seatIndex);
+                const actionLabel = getActionLabel(event.type);
+                const amount = getAmount(event);
+
+                return (
+                  <div
+                    key={event.id || `${street}-${index}`}
+                    className="text-xs text-white/90 grid grid-cols-[70px_auto] gap-1 items-center"
+                  >
+                    <span className="font-medium text-amber-400 truncate text-right pr-1">
+                      {playerName}
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <span className="text-white/90">{actionLabel}</span>
+                      {amount !== null && (
+                        <span className="text-emerald-400 font-medium">
+                          {amount}
+                        </span>
+                      )}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/ui/components/TableView/TableView.tsx
+++ b/src/ui/components/TableView/TableView.tsx
@@ -6,6 +6,7 @@ import {
 } from "../../../domain/showdown/resolveShowdown";
 import type { DealState, DealSummary, GameState } from "../../../domain/types";
 import { getHandRankLabel, getLowHandLabel } from "../../utils/handRankLabel";
+import { ActionHistoryPanel } from "./ActionHistoryPanel";
 import { PotStackBadge } from "./PotStackBadge";
 import { SeatPanel } from "./SeatPanel";
 
@@ -82,6 +83,12 @@ export const TableView: React.FC<TableViewProps> = ({
     <div
       className={`relative w-full h-full ${getTableSize(deal.playerCount)} bg-gradient-to-br from-green-900 to-green-800 rounded-2xl shadow-xl border-4 border-green-700 overflow-hidden p-8`}
     >
+      {/* アクション履歴パネル */}
+      <ActionHistoryPanel
+        eventLog={deal.eventLog}
+        seatOrder={deal.seatOrder}
+        players={game.players}
+      />
       {/* テーブル中央のポット表示 */}
       <div className="absolute top-1/2 left-1/2 z-10 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center">
         <PotStackBadge pot={deal.pot} ante={deal.ante} />

--- a/src/ui/utils/actionLabel.ts
+++ b/src/ui/utils/actionLabel.ts
@@ -40,3 +40,16 @@ export const getLastAction = (
   if (playerActions.length === 0) return null;
   return playerActions[playerActions.length - 1];
 };
+
+/**
+ * プレイヤーアクションのみをフィルタリングするためのタイプ一覧
+ */
+export const PLAYER_ACTION_TYPES = [
+  "BET",
+  "RAISE",
+  "CALL",
+  "FOLD",
+  "CHECK",
+  "BRING_IN",
+  "COMPLETE",
+] as const;


### PR DESCRIPTION
## 概要
Dealにおいて行われたプレイヤーのアクション履歴を、TableView内の左上にスクロール可能なリストとして表示する機能を実装しました。

## 変更内容

### ドメイン層
- `DealState`に`eventLog`プロパティを追加
- `startNewDeal`で`eventLog`を初期化
- `applyEvent`でイベント適用時に`eventLog`へ記録

### UI層
- `ActionHistoryPanel`コンポーネントを新規作成
- プレイヤーアクション（BET, RAISE, CALL, FOLD, CHECK, BRING_IN, COMPLETE）のみをフィルタリングして表示
- ストリートごとに区切って表示
- プレイヤー名とアクションを縦揃えで表示

## テスト結果
- ✅ リント: 0 エラー
- ✅ テスト: 153件 全てパス

Closes #44