### PR TITLE
#47 fix: ショーダウン時にCPUのハンドが公開されない不具合を修正

### DIFF
--- a/src/app/store/appStore.ts
+++ b/src/app/store/appStore.ts
@@ -257,6 +257,11 @@ const storeCreator = (set: any, get: any): AppStore => ({
             if (!state.game || !state.game.currentDeal) return;
 
             const finishedDeal = state.game.currentDeal;
+
+            // [FIX] 明示的にdealFinishedフラグを立てる
+            // これにより、フロントエンド（SeatPanel等）がハンド公開や役表示を行えるようになる
+            finishedDeal.dealFinished = true;
+
             // finishDealでGameStateを更新
             state.game = finishDeal(state.game, finishedDeal);
 


### PR DESCRIPTION
## 概要
ショーダウン時にCPUのハンドが公開されず、役判定も表示されない不具合を修正。

## 変更内容
- `appStore.ts`: DEAL_END時に`dealFinished`フラグを明示的に`true`に設定してから履歴に保存

## 検証
- `npm run test` - 全テスト通過
- `npm run lint` - エラーなし
- `npm run format` - 適用済み

Closes #47