### PR TITLE
fix: 7thストリートでfirst actorをupcardに基づいて判定するように修正

### DIFF
--- a/src/domain/engine/applyEvent.ts
+++ b/src/domain/engine/applyEvent.ts
@@ -261,6 +261,13 @@ const handleDealCard7th = (draft: Draft<DealState>, _event: DealCardEvent) => {
   const result = dealCard7th(draft.deck, activeSeats, draft.hands);
   draft.deck = result.deck;
   draft.hands = result.hands;
+
+  // 7thはダウンカードだがfirst actorはupcardに基づいて判定する（6thと同じロジック）
+  draft.currentActorIndex = pickFirstActorFromUpcards(
+    draft.gameType,
+    activeSeats,
+    draft.hands,
+  );
 };
 
 const getNextStreet = (


### PR DESCRIPTION
## 概要
7thストリートでfirst actorがupcardに基づいて判定されるように修正しました。

## 問題
6thと7thストリートでupcardは変わらないにも関わらず、7thストリートのfirst actorが6thストリートと異なることがありました。

## 原因
`handleDealCard7th`関数で`currentActorIndex`を再計算していなかったため、前のストリート終了時の`getNextActor`の結果のままになっていました。

## 修正内容
- `src/domain/engine/applyEvent.ts`: `handleDealCard7th`に`pickFirstActorFromUpcards`呼び出しを追加
- `test/domain/engine.test.ts`: 
  - テストケースを修正して正しい動作を検証
  - Razzでの7thストリートテストを追加
  - 6thと7thで同じfirst actorになることの検証テストを追加
  - `initialState`に`eventLog`プロパティを追加（TypeScriptエラー解消）

## テスト結果
- 全テスト155件通過
- lint/format問題なし

Closes #49