### PR TITLE
feat: display game number in rotation in TableView

### DIFF
--- a/src/ui/components/TableView/TableView.tsx
+++ b/src/ui/components/TableView/TableView.tsx
@@ -113,7 +113,9 @@ export const TableView: React.FC<TableViewProps> = ({
       <div className="absolute top-[56%] left-[44%] -translate-x-1/2 -translate-y-1/2 z-10">
         <div className="bg-amber-400/95 backdrop-blur-sm rounded-sm px-2 py-0.5 shadow-[0_4px_10px_rgba(0,0,0,0.5)] border border-amber-600/60">
           <span className="text-[10px] text-amber-950 tracking-tight">
-            <span className="font-black">{getGameTypeLabel(deal.gameType)}</span>
+            <span className="font-black">
+              {getGameTypeLabel(deal.gameType)}
+            </span>
             <span className="font-bold ml-0.5">
               (#{(dealIndex % game.rotation.dealPerGame) + 1}/
               {game.rotation.dealPerGame})


### PR DESCRIPTION
## 目的
Table Viewのゲーム種目表示バッジにおいて、その種目がローテーション内の何ゲーム目かを表示するようにします。

## 変更内容
- `TableView.tsx` で `dealIndex` と `game.rotation` を使用して、現在の種目内でのゲーム番号を算出。
- ゲーム種目ラベルの横に番号を表示（例: `Stud Hi #1/8`）。

## 関連Issue
Closes #51