### PR TITLE
#60 fix: ショーダウン時のゲーム番号表示を修正

### DIFF
--- a/src/ui/pages/PlayPage.tsx
+++ b/src/ui/pages/PlayPage.tsx
@@ -97,7 +97,7 @@ export const PlayPage: React.FC = () => {
             deal={displayDeal}
             game={game}
             dealSummary={dealSummary}
-            dealIndex={game.dealIndex}
+            dealIndex={isDealFinished ? game.dealIndex - 1 : game.dealIndex}
           />
         </div>
         {/* 2行目: ActionPanel/StartDealButton */}


### PR DESCRIPTION
## 概要
ショーダウン時に表示されるゲーム番号が、次のゲームの番号になっていたバグを修正。

## 変更内容
`PlayPage.tsx` で `TableView` に渡す `dealIndex` を修正:
- ディール終了時（`isDealFinished = true`）の場合は `game.dealIndex - 1` を渡す
- 進行中の場合は従来通り `game.dealIndex` を渡す

## 根本原因
`finishDeal` 関数でディール終了時に `game.dealIndex` が `+1` されるため、ショーダウン画面表示時には次のゲームのインデックスが格納されていた。

## 検証結果
- ✅ 型チェック通過
- ✅ Lint通過  
- ✅ 160テスト全て成功

Closes #60