### PR TITLE
#69 feat: ショーダウン以外でディール終了時は役を表示しない

### DIFF
--- a/src/ui/components/TableView/TableView.tsx
+++ b/src/ui/components/TableView/TableView.tsx
@@ -26,11 +26,15 @@ export const TableView: React.FC<TableViewProps> = ({
   dealSummary,
   dealIndex,
 }) => {
-  // 役の計算（dealFinished時のみ）
+  // 役の計算（ショーダウン時のみ：dealFinished かつ アクティブプレイヤーが2人以上）
   const handRankLabels: Record<number, string | null> = {};
   const lowRankLabels: Record<number, string | null> = {};
 
-  if (deal.dealFinished) {
+  // ショーダウン判定：アクティブプレイヤーが2人以上残っている場合のみ役を計算
+  const activePlayerCount = deal.players.filter((p) => p.active).length;
+  const isShowdown = deal.dealFinished && activePlayerCount >= 2;
+
+  if (isShowdown) {
     for (const seat of Object.keys(deal.hands)) {
       const seatIdx = Number(seat);
       const player = deal.players.find((p) => p.seat === seatIdx);


### PR DESCRIPTION
## 概要
ショーダウン以外（全員フォールドなど）でディールが終了した場合に、役（Hand Rank）の表示を行わないよう修正しました。

## 変更内容
- `TableView.tsx` において役の計算条件を変更
- 現在: `dealFinished === true` で役を計算
- 修正後: `dealFinished === true` かつ `activePlayerCount >= 2` （ショーダウン）の場合のみ役を計算

## 判定ロジック
| 条件 | 役の表示 |
|------|----------|
| ショーダウン（アクティブ2人以上） | ✅ 表示 |
| フォールドで1人残り | ❌ 非表示 |

## 検証結果
- ✅ Lint通過
- ✅ Format通過
- ✅ ビルド成功
- ✅ 全179テスト通過

Closes #69