### PR TITLE
feat: Tune Lv1 CPU betting logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -513,7 +512,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1698,7 +1696,6 @@
       "integrity": "sha512-gqkrWUsS8hcm0r44yn7/xZeV1ERva/nLgrLxFRUGb7aoNMIJfZJ3AC261zDQuOAKC7MiXai1WCpYc48jAHoShQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1709,7 +1706,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1855,7 +1851,6 @@
       "integrity": "sha512-sxSyJMaKp45zI0u+lHrPuZM1ZJQ8FaVD35k+UxVrha1yyvQ+TZuUYllUixwvQXlB7ixoDc7skf3lQPopZIvaQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.15",
         "fflate": "^0.8.2",
@@ -1964,7 +1959,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2273,7 +2267,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-11.0.1.tgz",
       "integrity": "sha512-naDCyggtcBWANtIrjQEajhhBEuL9b0Zg4zmlWK2CzS6xCWSE39/vvf4LqnMjUAWHBhot4m9MHCM/Z+mfWhUkiA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -2680,7 +2673,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2716,7 +2708,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2738,7 +2729,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2748,7 +2738,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3016,7 +3005,6 @@
       "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -3092,7 +3080,6 @@
       "integrity": "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.15",
         "@vitest/mocker": "4.0.15",

--- a/src/domain/cpu/decideLv1.ts
+++ b/src/domain/cpu/decideLv1.ts
@@ -206,7 +206,7 @@ export const decideLv1 = (
     // RAISE判定（強いハンド）
     if (legal.includes("RAISE")) {
       const raiseThreshold = thresholds.raiseThreshold + requiredDelta;
-      const aggressionAdjusted = params.aggression * 0.5; // 抑制気味
+      const aggressionAdjusted = params.aggression * 0.8; // 0.5 -> 0.8: Be more aggressive
       if (handScore >= raiseThreshold && rng() < aggressionAdjusted) {
         return "RAISE";
       }

--- a/src/domain/cpu/params.ts
+++ b/src/domain/cpu/params.ts
@@ -21,12 +21,12 @@ export interface CpuParamsLv1 {
  * デフォルトパラメータ（堅実寄り）
  */
 export const DEFAULT_PARAMS_LV1: CpuParamsLv1 = {
-  tightness: 0.75,
-  aggression: 0.35,
-  bluffFreq: 0.01,
-  semiBluffFreq: 0.03,
-  multiwayPenalty: 0.2,
-  bigBetFear: 0.3,
+  tightness: 0.2, // 0.75 -> 0.2: Requires less score to act
+  aggression: 0.6, // 0.35 -> 0.6: More likely to raise
+  bluffFreq: 0.05, // 0.01 -> 0.05: Slightly more random bluffs
+  semiBluffFreq: 0.15, // 0.03 -> 0.15: More semi-bluffs
+  multiwayPenalty: 0.1, // 0.2 -> 0.1: Less scared of multiway
+  bigBetFear: 0.2, // 0.3 -> 0.2: Less scared of big bets
 };
 
 /**
@@ -52,14 +52,14 @@ export const STREET_THRESHOLDS: Record<
   StreetThresholds
 > = {
   "3rd": {
-    completeThreshold: 70,
+    completeThreshold: 60, // 70 -> 60: One Pair likely competes
     betThreshold: 0,
     raiseThreshold: 0,
     foldThreshold: 40,
   },
   "4th": {
     completeThreshold: 0,
-    betThreshold: 62,
+    betThreshold: 58, // 62 -> 58: Weak pair can bet
     raiseThreshold: 75,
     foldThreshold: 42,
   },

--- a/src/domain/showdown/resolveShowdown.ts
+++ b/src/domain/showdown/resolveShowdown.ts
@@ -150,10 +150,7 @@ const isStraight = (
  * 7枚から最良の5枚を選んでHighHandResultを返す
  */
 export const evaluateStudHi = (cards: Card[]): HighHandResult => {
-  if (cards.length < 5) {
-    // 5枚未満の場合はエラー扱い（通常は発生しない）
-    return { rank: "HIGH_CARD", kickers: [] };
-  }
+  // if (cards.length < 5) return { rank: "HIGH_CARD", kickers: [] };
 
   const rankGroups = groupByRank(cards, rankToNumberHigh);
   const suitGroups = groupBySuit(cards);

--- a/test/domain/cpu/decideLv1.test.ts
+++ b/test/domain/cpu/decideLv1.test.ts
@@ -456,5 +456,46 @@ describe("decideLv1", () => {
       // 弱い手 + rng=1 -> CHECK
       expect(action).toBe("CHECK");
     });
+    it("相手に高ランクカードが見えていても、ワンペアがあれば積極的にBETすること（チューニング後）", () => {
+      // Me: Pair of 5s (Score 64)
+      // Opponent: Upcards A, K (Penalty 4) -> Net 60
+      // Threshold: 58 (was 62)
+      const state = createTestState({
+        street: "4th",
+        currentBet: 0,
+        hands: {
+          0: {
+            downCards: [
+              { rank: "A", suit: "s" } as Card,
+              { rank: "K", suit: "d" } as Card,
+            ],
+            upCards: [
+              { rank: "A", suit: "h" } as Card, // High
+              { rank: "K", suit: "c" } as Card, // High -> highCards >= 2 -> Penalty 4
+            ],
+          },
+          1: {
+            downCards: [
+              { rank: "5", suit: "c" } as Card,
+              { rank: "5", suit: "h" } as Card, // Pair -> Score 64
+            ],
+            upCards: [
+              { rank: "2", suit: "d" } as Card,
+              { rank: "3", suit: "s" } as Card,
+            ],
+          },
+        },
+      });
+
+      const ctx: CpuDecisionContext = {
+        state,
+        seat: 1,
+        allowedActions: ["CHECK", "BET"],
+      };
+
+      const action = decideLv1(ctx, () => 0.5);
+
+      expect(action).toBe("BET");
+    });
   });
 });


### PR DESCRIPTION
## 目的
Lv1 CPUがbetしなさすぎる問題を修正し、より攻撃的な振る舞いをするように調整。

## 変更内容
- `params.ts`: Tightness, Aggression, SemiBluffFreq などのパラメータを調整
- `decideLv1.ts`: RAISE判定時のAggression減衰を緩和 (0.5 -> 0.8)
- `resolveShowdown.ts`: 5枚未満のカードでもペア等を認識するよう修正
- `decideLv1.test.ts`: 検証用テストケースを追加

## テスト結果
全180テスト通過

Closes #71