### PR TITLE
#77 fix: CPU 3rdストリートのアクションロジック修正

### DIFF
--- a/src/domain/cpu/decideLv1.ts
+++ b/src/domain/cpu/decideLv1.ts
@@ -153,19 +153,22 @@ export const decideLv1 = (
   const numActive = obs.players.filter((p) => p.active).length;
   const drawScore = getDrawScore(obs);
 
-  // === 3rd Bring-in 処理 ===
-  if (obs.street === "3rd" && obs.bringInIndex === obs.me.seat) {
+  // === 3rdストリート処理 ===
+  if (obs.street === "3rd") {
+    // ブリングインプレイヤーの初回アクション: 常にBRING_IN
+    if (legal.includes("BRING_IN")) {
+      return "BRING_IN";
+    }
+
+    // 非ブリングインプレイヤー: COMPLETE判定（閾値以上の場合）
     if (legal.includes("COMPLETE")) {
       const completeThreshold = thresholds.completeThreshold;
-      console.log("completeThreshold: ", completeThreshold);
-
       if (handScore >= completeThreshold) {
         return "COMPLETE";
       }
     }
-    if (legal.includes("BRING_IN")) {
-      return "BRING_IN";
-    }
+
+    // 3rdでcurrentBet > 0の場合は通常のCALL/FOLD/RAISE判定へ
   }
 
   // === currentBet == 0 の処理（CHECK / BET） ===


### PR DESCRIPTION
## 概要

CPU 3rdストリートのアクションロジックを修正しました。

## 変更内容

### `decideLv1.ts`
- **ブリングインプレイヤーの初回アクション**: 常にBRING_IN選択（COMPLETEしない）
- **非ブリングインプレイヤー**: COMPLETE権がある場合、閾値以上でCOMPLETE選択
- 不要な`console.log`を削除

### `decideLv1.test.ts`
- テストケースを4件更新/追加
  - ブリングインプレイヤーは強い手でもBRING_IN
  - 非ブリングインプレイヤー（強い手）→ COMPLETE
  - 非ブリングインプレイヤー（弱い手）→ CALL
  - COMPLETE後にRAISEされた場合の対応

## テスト結果

- ✅ 全183件通過
- ✅ lint/format OK

Closes #77