### PR TITLE
#79 fix: COMPLETE後のRAISE額が正しく計算されないバグを修正

### DIFF
--- a/src/domain/engine/applyEvent.ts
+++ b/src/domain/engine/applyEvent.ts
@@ -134,12 +134,14 @@ const handleBetting = (
   player.committedThisStreet += actualAdded;
   draft.pot += actualAdded;
 
-  draft.currentBet = event.amount;
-
-  // raiseCountの更新
+  // currentBetの更新
+  // RAISE: 増分を加算（仕様書 7.4: currentBet += streetBetUnit）
+  // BET/COMPLETE/BRING_IN: amountをそのまま設定
   if (event.type === "RAISE") {
+    draft.currentBet += event.amount;
     draft.raiseCount += 1;
   } else {
+    draft.currentBet = event.amount;
     // BRING_IN, COMPLETE, BETはraiseCountを0にリセット
     draft.raiseCount = 0;
   }

--- a/src/ui/components/play/ActionPanel.tsx
+++ b/src/ui/components/play/ActionPanel.tsx
@@ -59,7 +59,7 @@ export const ActionPanel: React.FC<ActionPanelProps> = () => {
           deal.street === "3rd" || deal.street === "4th"
             ? deal.smallBet
             : deal.bigBet;
-        return `Raise (${raiseUnit})`;
+        return `Raise to (${deal.currentBet + raiseUnit})`;
       }
       case "CALL": {
         const toCall = Math.max(


### PR DESCRIPTION
## 概要

COMPLETE後のRAISE額が正しく計算されないバグを修正しました。

Issue: #79

---

## 変更内容

### 1. `applyEvent.ts`

RAISE時の`currentBet`更新ロジックを仕様通りに修正：
- RAISE: `currentBet += event.amount`（増分を加算）
- BET/COMPLETE/BRING_IN: `currentBet = event.amount`（そのまま設定）

### 2. `ActionPanel.tsx`

RAISEボタンのラベルを最終ベット額表示に変更：
```diff
- return `Raise (${raiseUnit})`;
+ return `Raise to (${deal.currentBet + raiseUnit})`;
```

### 3. `ActionHistoryPanel.tsx`

アクション履歴でRAISEの最終ベット額を計算して表示するよう`getDisplayAmount`関数を追加。

### 4. `engine.test.ts`

以下のテストケースを追加：
- COMPLETEでcurrentBetがsmallBetになること
- COMPLETE後のRAISEでcurrentBetが正しく増加すること
- 連続RAISEで正しく計算されること
- BigBetストリートでRAISEが正しく機能すること

---

## 検証結果

| 検証項目 | 結果 |
|---------|------|
| 全テスト (187件) | ✅ 通過 |
| Lint | ✅ エラーなし |
| Format | ✅ 適用済み |

---

Closes #79