### PR TITLE
#83 feat: ゲーム種目変更時に通知オーバーレイを表示

### DIFF
--- a/src/ui/components/TableView/GameTypeChangeOverlay.tsx
+++ b/src/ui/components/TableView/GameTypeChangeOverlay.tsx
@@ -1,0 +1,102 @@
+import type React from "react";
+import { useEffect, useState } from "react";
+import type { GameType } from "../../../domain/types";
+import { getGameTypeLabel } from "../../utils/labelHelper";
+
+interface GameTypeChangeOverlayProps {
+  /** 現在のゲーム種目 */
+  currentGameType: GameType;
+  /** 前回のゲーム種目（初回ディールの場合はnull） */
+  previousGameType: GameType | null;
+  /** ディールが進行中かどうか */
+  isDealActive: boolean;
+}
+
+/**
+ * ゲーム種目変更時にフルスクリーン通知を表示するオーバーレイコンポーネント
+ * 種目が変わった場合のみ2.5秒間表示され、自動的にフェードアウトする
+ */
+export const GameTypeChangeOverlay: React.FC<GameTypeChangeOverlayProps> = ({
+  currentGameType,
+  previousGameType,
+  isDealActive,
+}) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [isFading, setIsFading] = useState(false);
+
+  // ゲーム種目の変更を検知
+  const hasGameTypeChanged =
+    previousGameType !== null &&
+    previousGameType !== currentGameType &&
+    isDealActive;
+
+  useEffect(() => {
+    if (hasGameTypeChanged) {
+      // 表示開始
+      setIsVisible(true);
+      setIsFading(false);
+
+      // 2秒後にフェードアウト開始
+      const fadeTimer = setTimeout(() => {
+        setIsFading(true);
+      }, 2000);
+
+      // 2.5秒後に完全に非表示
+      const hideTimer = setTimeout(() => {
+        setIsVisible(false);
+        setIsFading(false);
+      }, 2500);
+
+      return () => {
+        clearTimeout(fadeTimer);
+        clearTimeout(hideTimer);
+      };
+    }
+  }, [hasGameTypeChanged]);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 flex items-center justify-center pointer-events-none transition-opacity duration-500 ${
+        isFading ? "opacity-0" : "opacity-100"
+      }`}
+    >
+      {/* 背景のオーバーレイ（半透明） */}
+      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" />
+
+      {/* 通知カード */}
+      <div
+        className={`relative transform transition-all duration-300 ${
+          isFading ? "scale-95" : "scale-100"
+        }`}
+      >
+        <div className="bg-gradient-to-br from-amber-500 to-amber-600 rounded-2xl px-10 py-8 shadow-2xl border-2 border-amber-300/50">
+          {/* 装飾的なリングエフェクト */}
+          <div className="absolute inset-0 rounded-2xl animate-pulse bg-amber-400/20" />
+
+          <div className="relative text-center space-y-3">
+            {/* ヘッダーテキスト */}
+            <p className="text-amber-100 text-sm font-medium tracking-wider uppercase">
+              Game Type Changed
+            </p>
+
+            {/* ゲーム種目名 */}
+            <h2 className="text-white text-4xl font-black tracking-tight drop-shadow-lg">
+              {getGameTypeLabel(currentGameType)}
+            </h2>
+
+            {/* 下部のアクセント */}
+            <div className="flex items-center justify-center gap-2 pt-2">
+              <div className="h-0.5 w-12 bg-amber-200/50 rounded-full" />
+              <div className="h-1.5 w-1.5 bg-amber-200 rounded-full" />
+              <div className="h-0.5 w-12 bg-amber-200/50 rounded-full" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/ui/pages/PlayPage.tsx
+++ b/src/ui/pages/PlayPage.tsx
@@ -3,6 +3,7 @@ import { useAppStore } from "../../app/store/appStore";
 import type { GameState } from "../../domain/types";
 import { ActionPanel } from "../components/play/ActionPanel";
 import { HamburgerMenu } from "../components/play/HamburgerMenu";
+import { GameTypeChangeOverlay } from "../components/TableView/GameTypeChangeOverlay";
 import { TableView } from "../components/TableView/TableView";
 import { UI_STRINGS } from "../constants/uiStrings";
 
@@ -80,8 +81,21 @@ export const PlayPage: React.FC = () => {
       ? game.dealHistory.find((s) => s.dealId === displayDeal.dealId) || null
       : null;
 
+  // 前回のゲーム種目を取得（dealHistoryの最初のエントリ = 直前のディール）
+  const previousGameType =
+    game.dealHistory.length > 0 ? game.dealHistory[0].gameType : null;
+
   return (
     <div className="h-full w-full flex flex-col p-4 overflow-hidden">
+      {/* ゲーム種目変更通知オーバーレイ */}
+      {game.currentDeal && (
+        <GameTypeChangeOverlay
+          currentGameType={game.currentDeal.gameType}
+          previousGameType={previousGameType}
+          isDealActive={!isDealFinished}
+        />
+      )}
+
       {/* ハンバーガーメニュー */}
       <div className="flex-shrink-0 flex justify-end mb-2">
         <HamburgerMenu


### PR DESCRIPTION
## 概要
ゲーム種目が変わったタイミングで、ユーザーにわかりやすいフルスクリーン通知オーバーレイを表示する機能を追加。

## 変更内容

### 新規ファイル
- `src/ui/components/TableView/GameTypeChangeOverlay.tsx`
  - ゲーム種目変更時に表示されるオーバーレイコンポーネント
  - 2秒間表示後、0.5秒でフェードアウト
  - amber色のグラデーション背景 + 新しいゲーム種目名を表示

### 変更ファイル
- `src/ui/pages/PlayPage.tsx`
  - `GameTypeChangeOverlay`コンポーネントの統合
  - 前回ディールのgameTypeを取得して比較するロジックを追加

## 動作仕様
- 新しいディール開始時に、前回ディールとゲーム種目が異なる場合のみオーバーレイを表示
- 初回ディール（前回ディールがない）の場合は表示しない
- ディール終了後は表示しない

## テスト結果
- `npm run lint` ✅
- `npm run format` ✅
- `npm run test` ✅ (187テスト全パス)

Closes #83