### PR TITLE
feat: プレイヤー前のチップ表示機能とポット表示の改善

### DIFF
--- a/src/domain/engine/applyEvent.ts
+++ b/src/domain/engine/applyEvent.ts
@@ -126,7 +126,17 @@ const handleBetting = (
   event: BetEvent | RaiseEvent | CompleteEvent | BringInEvent,
 ) => {
   const player = draft.players[event.seat];
-  const added = event.amount - player.committedThisStreet;
+
+  // RAISEの場合、event.amountは増分（streetBetUnit）
+  // プレイヤーは currentBet + event.amount まで出す必要がある
+  let targetAmount: number;
+  if (event.type === "RAISE") {
+    targetAmount = draft.currentBet + event.amount;
+  } else {
+    targetAmount = event.amount;
+  }
+
+  const added = targetAmount - player.committedThisStreet;
   const actualAdded = Math.min(player.stack, added);
 
   player.stack -= actualAdded;

--- a/src/ui/components/TableView/BetChips.tsx
+++ b/src/ui/components/TableView/BetChips.tsx
@@ -1,0 +1,106 @@
+import type React from "react";
+import { calculateChips } from "../../utils/chipCalculator";
+import { Chip } from "./PotStackBadge";
+
+// チップのサイズとレイアウト定数（BetChipsはPotStackBadgeより小さく表示）
+const CHIP_SIZE = 20; // チップの直径（px）
+const STACK_SPACING = 20; // スタック間の横方向の間隔（px）
+const STACK_VERTICAL_OFFSET = -2; // スタック内のチップの縦方向の重なり（px）
+const STACK_BASE_HEIGHT = 24; // スタックのベース高さ（px）
+const STACK_HEIGHT_MULTIPLIER = 2; // スタックカウントから高さを計算する係数
+
+// z-indexの定数
+const Z_INDEX_BASE = 5; // z-indexのベース値（SeatPanelより低く）
+const Z_INDEX_INCREMENT = 5; // z-indexの増分
+
+interface BetChipsProps {
+  amount: number; // committedThisStreet
+  ante: number; // 最小単位
+  seatAngle: number; // プレイヤーの角度（0-360度）
+  className?: string;
+}
+
+export const BetChips: React.FC<BetChipsProps> = ({
+  amount,
+  ante,
+  seatAngle,
+  className,
+}) => {
+  const chipStacks = calculateChips(amount, ante);
+
+  if (chipStacks.length === 0 || amount === 0) {
+    return null;
+  }
+
+  // チップの表示位置を計算（SeatPanelとテーブル中央の中間地点）
+  // radius * 0.4 程度の位置に配置
+  const radius = 245 * 0.4; // SeatPanelのradiusの40%
+  const x = Math.cos((seatAngle * Math.PI) / 180) * radius;
+  const y = Math.sin((seatAngle * Math.PI) / 180) * radius;
+
+  return (
+    <div
+      className={[
+        "absolute transform -translate-x-1/2 -translate-y-1/2 flex flex-col items-center",
+        className ?? "",
+      ].join(" ")}
+      style={{
+        left: `calc(50% + ${x}px)`,
+        top: `calc(50% + ${y}px)`,
+      }}
+    >
+      {/* チップスタックの表示 */}
+      <div
+        className="relative mx-auto"
+        style={{
+          width:
+            chipStacks.length > 0
+              ? `${(chipStacks.length - 1) * STACK_SPACING + CHIP_SIZE}px`
+              : "0px",
+          height: `${
+            STACK_BASE_HEIGHT +
+            Math.max(...chipStacks.map((s) => s.stackCount - 1), 0) *
+              STACK_HEIGHT_MULTIPLIER
+          }px`,
+        }}
+      >
+        {chipStacks.map((chipStack, stackIndex) => {
+          const stackX = stackIndex * STACK_SPACING; // 各スタックの横位置
+          const baseZ = Z_INDEX_BASE + stackIndex * Z_INDEX_INCREMENT;
+
+          // 各スタック内のチップを重ねて表示
+          return chipStack.stackCount > 0
+            ? Array.from({ length: chipStack.stackCount }).map(
+                (_, chipIndex) => {
+                  const stackY = chipIndex * STACK_VERTICAL_OFFSET; // 縦方向の重なり
+                  const z = baseZ + chipIndex;
+
+                  return (
+                    <div
+                      // biome-ignore lint/suspicious/noArrayIndexKey: decorative list
+                      key={`${stackIndex}-${chipIndex}`}
+                      className="absolute"
+                      style={{
+                        left: stackX,
+                        top: stackY,
+                        zIndex: z,
+                      }}
+                    >
+                      <Chip spec={chipStack.spec} size={CHIP_SIZE} />
+                    </div>
+                  );
+                },
+              )
+            : null;
+        })}
+      </div>
+
+      {/* 金額ラベル */}
+      <div className="mt-1 bg-black/70 backdrop-blur-sm rounded px-2 py-0.5 shadow-sm">
+        <span className="text-[10px] font-bold text-white tabular-nums">
+          {amount}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/src/ui/components/TableView/PotStackBadge.tsx
+++ b/src/ui/components/TableView/PotStackBadge.tsx
@@ -85,7 +85,7 @@ const CHIP_TONE: Record<
   },
 };
 
-const Chip: React.FC<{
+export const Chip: React.FC<{
   spec: ChipSpec;
   size?: number; // px
   className?: string;

--- a/src/ui/components/TableView/SeatPanel.tsx
+++ b/src/ui/components/TableView/SeatPanel.tsx
@@ -13,7 +13,6 @@ interface SeatPanelProps {
   deal: DealState; // カード情報を取得するために必要
   isDealFinished: boolean; // ディールが終了しているかどうか
   isWinner?: boolean; // 勝者かどうか
-  winningsAmount?: number | null; // 獲得額（正の値のみ）
   handRankLabel?: string | null; // High役の日本語ラベル
   lowRankLabel?: string | null; // Low役のラベル
 }
@@ -28,7 +27,6 @@ export const SeatPanel: React.FC<SeatPanelProps> = ({
   deal,
   isDealFinished,
   isWinner = false,
-  winningsAmount = null,
   handRankLabel = null,
   lowRankLabel = null,
 }) => {
@@ -110,13 +108,6 @@ export const SeatPanel: React.FC<SeatPanelProps> = ({
           {!player.active && (
             <div className="text-xs text-destructive font-semibold">FOLD</div>
           )}
-          {winningsAmount !== null &&
-            winningsAmount !== undefined &&
-            winningsAmount > 0 && (
-              <div className="text-sm font-bold text-poker-gold">
-                +{winningsAmount}
-              </div>
-            )}
           <div className="pt-2 border-t space-y-1">
             <div className="flex justify-between text-xs">
               <span className="font-semibold">{player.stack}</span>


### PR DESCRIPTION
# PlayerSeat周辺の表示整理 - チップ表示機能の追加

## 概要
bet/call/raiseなどのアクション時にプレイヤーの前（SeatPanelとテーブル中央の間）にチップを視覚的に表示する機能を実装しました。

さらに、以下の改善も実施しました：
- 中央ポット表示の修正（confirmedPot計算）
- ショーダウン時の表示改善
- RAISE時のcommittedThisStreet計算バグ修正

Closes #88

## 実装内容

### 新規作成したファイル

#### BetChips.tsx

プレイヤーのベット額を視覚的に表示する新規コンポーネントです。

**主な機能**:
- `committedThisStreet` に基づいてチップを視覚的に表示
- 既存の `chipCalculator` を再利用してチップ構成を計算
- `PotStackBadge` の `Chip` コンポーネントを再利用してデザインの一貫性を維持
- プレイヤーの座席位置（角度）に応じてチップの表示位置を自動調整

**レイアウト**:
- チップサイズ: 20px（PotStackBadgeの26pxより小さく）
- 配置位置: SeatPanelとテーブル中央の中間地点（radius * 0.4）
- z-index: 5（SeatPanelより低く、テーブルより高く）

---

### 変更したファイル

#### PotStackBadge.tsx

`Chip` コンポーネントを `export` に変更し、`BetChips` から再利用できるようにしました。

#### TableView.tsx

**主な変更**:
1. `BetChips` コンポーネントをインポート
2. プレイヤーの角度（angle）を計算するロジックを追加
3. 中央ポット表示をconfirmedPot（前のストリートまでに確定したポット額）に修正
4. ショーダウン時に中央ポット・ベットチップを非表示
5. ショーダウン時に勝者のプレイヤー前に獲得チップを表示

**重要な実装ポイント**:
- `committedThisStreet` は各ストリート終了時にリセットされるため、新しいストリートに移行すると自動的にチップ表示が消える
- プレイヤーの角度計算により、2人〜7人のどの構成でも適切な位置にチップが配置される

#### applyEvent.ts

RAISE時のcommittedThisStreet計算を修正：
- RAISEの場合、プレイヤーは「前のcurrentBetにコール + event.amount（増分）」を支払う
- これにより、A: complete 400, B: raise の場合、Bの前に800のチップが正しく表示される

#### SeatPanel.tsx

ショーダウン時の数値表示（"+3000"）を削除し、代わりにプレイヤー前にチップの集合を表示するように変更

---

## 検証結果

### 自動テスト

全てのテストが通過しました:
```
✓ 189 tests passed (14 test files)
```

RAISE時のロジック修正に対する新しいテストケースを追加（+2テスト）

### コード品質チェック

Lint/Formatチェックも問題なく通過:
```
✓ npm run lint  - No fixes applied
✓ npm run format - No fixes applied
```

---

## 技術的な判断

### チップ表示のタイミング
`committedThisStreet > 0` を条件に表示することで、以下のシナリオで適切に動作します:
- **Bring In**: Bring Inプレイヤーの前にチップが表示される
- **Bet/Call/Raise**: アクション実行後、各プレイヤーの前にチップが表示される
- **Street Advance**: 新しいストリートに移行すると、`committedThisStreet` がリセットされ、チップ表示が自動的に消える

### ショーダウン時の表示
- 中央のポット表示を非表示
- 各プレイヤー前のベットチップを非表示
- 勝者のプレイヤー前に獲得したチップの集合を表示

### デザインの一貫性
既存の `PotStackBadge` と同じチップデザインを再利用することで、UIの統一感を保ちました。チップサイズはPotStackBadgeより小さくし、プレイヤーのベットチップであることを視覚的に区別しています。

### レイアウトの柔軟性
プレイヤー数（2〜7人）に応じて、チップの配置が自動的に調整されるため、どの構成でも適切に表示されます。