### PR TITLE
feat(ui): プレイヤーパネルとショーダウン表示の改善

### DIFF
--- a/src/ui/components/TableView/BetChips.tsx
+++ b/src/ui/components/TableView/BetChips.tsx
@@ -18,6 +18,11 @@ interface BetChipsProps {
   ante: number; // 最小単位
   seatAngle: number; // プレイヤーの角度（0-360度）
   className?: string;
+  handRankLabel?: string | null; // High役のラベル（ショーダウン時のみ）
+  lowRankLabel?: string | null; // Low役のラベル（ショーダウン時のみ）
+  isWinnerHigh?: boolean; // High役でポットを取得したかどうか
+  isWinnerLow?: boolean; // Low役でポットを取得したかどうか
+  gameType?: "studHi" | "razz" | "stud8"; // ゲームの種類
 }
 
 export const BetChips: React.FC<BetChipsProps> = ({
@@ -25,6 +30,11 @@ export const BetChips: React.FC<BetChipsProps> = ({
   ante,
   seatAngle,
   className,
+  handRankLabel = null,
+  lowRankLabel = null,
+  isWinnerHigh = false,
+  isWinnerLow = false,
+  gameType,
 }) => {
   const chipStacks = calculateChips(amount, ante);
 
@@ -41,7 +51,7 @@ export const BetChips: React.FC<BetChipsProps> = ({
   return (
     <div
       className={[
-        "absolute transform -translate-x-1/2 -translate-y-1/2 flex flex-col items-center",
+        "absolute transform -translate-x-1/2 -translate-y-1/2 flex flex-col items-center z-20",
         className ?? "",
       ].join(" ")}
       style={{
@@ -49,6 +59,39 @@ export const BetChips: React.FC<BetChipsProps> = ({
         top: `calc(50% + ${y}px)`,
       }}
     >
+      {/* 役情報（ショーダウン時のみ） */}
+      {(handRankLabel || lowRankLabel) && (
+        <div className="relative z-20 mb-1 bg-black/80 backdrop-blur-sm rounded px-2 py-1 shadow-md space-y-0.5">
+          {handRankLabel && (
+            <div
+              className={`text-[10px] font-semibold ${
+                isWinnerHigh ? "text-poker-gold" : "text-gray-400"
+              }`}
+            >
+              High: {handRankLabel}
+            </div>
+          )}
+          {lowRankLabel && (
+            <div
+              className={`text-[10px] font-semibold ${
+                lowRankLabel === "ローなし"
+                  ? "text-gray-400"
+                  : // Razzの場合はwinnersHighに勝者が入っているため、isWinnerHighを使用
+                    gameType === "razz"
+                    ? isWinnerHigh
+                      ? "text-poker-gold"
+                      : "text-gray-400"
+                    : isWinnerLow
+                      ? "text-poker-gold"
+                      : "text-gray-400"
+              }`}
+            >
+              Low: {lowRankLabel}
+            </div>
+          )}
+        </div>
+      )}
+
       {/* チップスタックの表示 */}
       <div
         className="relative mx-auto"

--- a/src/ui/components/TableView/TableView.tsx
+++ b/src/ui/components/TableView/TableView.tsx
@@ -64,20 +64,21 @@ export const TableView: React.FC<TableViewProps> = ({
     }
   }
 
-  // 勝者情報をseatIndexベースに変換
-  const winnerSeats = new Set<number>();
+  // 勝者情報をseatIndexベースに変換（High/Low別々に管理）
+  const winnersHighSeats = new Set<number>();
+  const winnersLowSeats = new Set<number>();
   if (dealSummary) {
     // PlayerIdからseatIndexに変換
     dealSummary.winnersHigh.forEach((playerId) => {
       const seatIndex = deal.seatOrder.indexOf(playerId);
       if (seatIndex >= 0) {
-        winnerSeats.add(seatIndex);
+        winnersHighSeats.add(seatIndex);
       }
     });
     dealSummary.winnersLow?.forEach((playerId) => {
       const seatIndex = deal.seatOrder.indexOf(playerId);
       if (seatIndex >= 0) {
-        winnerSeats.add(seatIndex);
+        winnersLowSeats.add(seatIndex);
       }
     });
   }
@@ -161,7 +162,8 @@ export const TableView: React.FC<TableViewProps> = ({
         const playerName =
           gamePlayer?.name ?? UI_STRINGS.COMMON.PLAYER_DEFAULT(index + 1);
         const isCurrentActor = deal.currentActorIndex === index;
-        const isWinner = winnerSeats.has(index);
+        const isWinnerHigh = winnersHighSeats.has(index);
+        const isWinnerLow = winnersLowSeats.has(index);
 
         // 獲得額を取得（potShareから）
         const playerId = deal.seatOrder[index];
@@ -190,7 +192,8 @@ export const TableView: React.FC<TableViewProps> = ({
               players={deal.players}
               deal={deal}
               isDealFinished={deal.dealFinished}
-              isWinner={isWinner}
+              isWinnerHigh={isWinnerHigh}
+              isWinnerLow={isWinnerLow}
               handRankLabel={handRankLabels[player.seat] ?? null}
               lowRankLabel={lowRankLabels[player.seat] ?? null}
             />
@@ -208,6 +211,11 @@ export const TableView: React.FC<TableViewProps> = ({
                 amount={winningsAmount}
                 ante={deal.ante}
                 seatAngle={angle}
+                handRankLabel={handRankLabels[player.seat] ?? null}
+                lowRankLabel={lowRankLabels[player.seat] ?? null}
+                isWinnerHigh={isWinnerHigh}
+                isWinnerLow={isWinnerLow}
+                gameType={deal.gameType}
               />
             )}
           </React.Fragment>


### PR DESCRIPTION
## 概要

プレイヤーパネルとショーダウン時の表示を改善し、より見やすく情報密度の高いUIを実現しました。

Fixes #93

## 主な変更内容

### プレイヤーパネルの改善
1. **プレイヤー種別のアイコン化** - (CPU/You)のテキストをアイコンに変更
2. **余白の最適化** - パネルをよりコンパクトに表示
3. **カードとの重なり配置** - スペースを節約
4. **レイアウトの再構成** - アクションと役の位置を入れ替え
5. **役の色分け表示** - ポット取得=ゴールド、未取得=グレー

### ショーダウン表示の改善
1. **チップ表示に役情報を追加** - 獲得チップの近くに役を表示
2. **Razzの役色判定修正** - Low役でも正しく色分け
3. **z-indexの調整** - 役情報を最前面に表示

## 変更ファイル

- `SeatPanel.tsx`
- `TableView.tsx`
- `BetChips.tsx`

**変更サマリー**: 3 files changed, 112 insertions(+), 42 deletions(-)

## 検証結果

- ✅ Lint: 合格
- ✅ テスト: 189テスト全て合格
