### PR TITLE
#97 feat: Stud8専用CPU Lv1戦略を実装

### DIFF
--- a/src/domain/cpu/decideLv1.ts
+++ b/src/domain/cpu/decideLv1.ts
@@ -1,4 +1,5 @@
 import { decideRazzLv1 } from "./decideRazzLv1";
+import { decideStud8Lv1 } from "./decideStud8Lv1";
 import { buildObservation } from "./observation";
 import {
   type CpuParamsLv1,
@@ -141,6 +142,11 @@ export const decideLv1 = (
   // Razz専用戦略を使用
   if (obs.gameType === "razz") {
     return decideRazzLv1(ctx);
+  }
+
+  // Stud8専用戦略を使用
+  if (obs.gameType === "stud8") {
+    return decideStud8Lv1(ctx, rng);
   }
 
   // 3. ハンドスコアを計算

--- a/src/domain/cpu/decideStud8Lv1.ts
+++ b/src/domain/cpu/decideStud8Lv1.ts
@@ -1,0 +1,292 @@
+/**
+ * Stud8専用 CPU Lv1 戦略
+ *
+ * High/Low両面を考慮した戦略ロジック
+ */
+
+import { groupByRank } from "../showdown/resolveShowdown";
+import type { Card } from "../types";
+import { buildObservation, type CpuObservation } from "./observation";
+import type { ActionType, CpuDecisionContext } from "./policy";
+import { calcStud8Score, calcStudHiScore } from "./scoring";
+
+/**
+ * ランクを数値に変換（Low用: A=1）
+ */
+const rankToNumberLow = (rank: Card["rank"]): number => {
+  const map: Record<Card["rank"], number> = {
+    A: 1,
+    K: 13,
+    Q: 12,
+    J: 11,
+    T: 10,
+    "9": 9,
+    "8": 8,
+    "7": 7,
+    "6": 6,
+    "5": 5,
+    "4": 4,
+    "3": 3,
+    "2": 2,
+  };
+  return map[rank];
+};
+
+/**
+ * 自分の既知カード（downCards + upCards）を取得
+ */
+const getMeKnownCards = (obs: CpuObservation): Card[] => {
+  return [...obs.me.downCards, ...obs.me.upCards];
+};
+
+/**
+ * カードが全て8以下かどうか判定
+ */
+const hasAll8OrBelow = (cards: Card[]): boolean => {
+  return cards.every((c) => rankToNumberLow(c.rank) <= 8);
+};
+
+/**
+ * ペアがあるかどうか判定
+ */
+const hasPair = (cards: Card[]): boolean => {
+  const ranks = cards.map((c) => c.rank);
+  const rankSet = new Set(ranks);
+  return rankSet.size < ranks.length;
+};
+
+/**
+ * ハイカード(9+)の枚数を取得
+ */
+const countHighCards = (cards: Card[]): number => {
+  return cards.filter((c) => rankToNumberLow(c.rank) >= 9).length;
+};
+
+/**
+ * Low完成可能性判定
+ * - 現在の8以下のユニークランク数と残りカード枚数から判定
+ * - 最低2枚の8以下が必要
+ */
+const hasLowPotential = (cards: Card[]): boolean => {
+  const uniqueLowRanks = new Set(
+    cards.map((c) => rankToNumberLow(c.rank)).filter((r) => r <= 8),
+  );
+  const cardsRemaining = 7 - cards.length;
+  const lowCardsNeeded = 5 - uniqueLowRanks.size;
+  // 残りカードで必要枚数を引ける可能性があり、かつ現在2枚以上の8以下がある
+  return lowCardsNeeded <= cardsRemaining && uniqueLowRanks.size >= 2;
+};
+
+/**
+ * 相手全員がハイカードのみ（upcard全て9+）か判定
+ */
+const allOpponentsHighOnly = (
+  mySeat: number,
+  players: CpuObservation["players"],
+): boolean => {
+  const opponents = players.filter((p) => p.seat !== mySeat && p.active);
+  if (opponents.length === 0) return false;
+
+  return opponents.every((p) =>
+    p.upCards.every((c) => rankToNumberLow(c.rank) >= 9),
+  );
+};
+
+/**
+ * Big Bet Street かどうか（5th以降）
+ */
+const isBigBetStreet = (street: string): boolean => {
+  return street === "5th" || street === "6th" || street === "7th";
+};
+
+/**
+ * High/Lowスコア計算（スクープ判定用）
+ */
+const calcHighLowScores = (
+  obs: CpuObservation,
+): { highScore: number; lowScore: number } => {
+  const meKnown = getMeKnownCards(obs);
+
+  // High スコア
+  const highScore = calcStudHiScore(obs);
+
+  // Low スコア計算
+  const uniqueLowRanks = new Set(
+    meKnown.map((c) => rankToNumberLow(c.rank)).filter((r) => r <= 8),
+  );
+  const lowUniqueCount = uniqueLowRanks.size;
+
+  const rankGroups = groupByRank(meKnown);
+  const pairCount = Array.from(rankGroups.values()).filter(
+    (cards) => cards.length >= 2,
+  ).length;
+
+  const highCount = meKnown.filter((c) => rankToNumberLow(c.rank) >= 9).length;
+  const worstRank = Math.max(...meKnown.map((c) => rankToNumberLow(c.rank)));
+
+  let lowBase = 40;
+  lowBase += lowUniqueCount * 12;
+  lowBase -= pairCount * 12;
+  lowBase -= highCount * 10;
+  lowBase -= Math.max(0, worstRank - 8) * 3;
+  const lowScore = Math.max(0, Math.min(100, lowBase));
+
+  return { highScore, lowScore };
+};
+
+/**
+ * Stud8 Lv1 意思決定ロジック
+ */
+export const decideStud8Lv1 = (
+  ctx: CpuDecisionContext,
+  rng: () => number = Math.random,
+): ActionType => {
+  const { state, seat, allowedActions } = ctx;
+  const obs = buildObservation(state, seat);
+  const legal = allowedActions as ActionType[];
+
+  // 選択肢が1つならそれを返す
+  if (legal.length === 1) return legal[0];
+  if (legal.length === 0) return "FOLD";
+
+  const myAllCards = getMeKnownCards(obs);
+  const isBringInPlayer = obs.bringInIndex === seat;
+  const isAll8OrBelow = hasAll8OrBelow(myAllCards);
+  const myHasPair = hasPair(myAllCards);
+  const highCardCount = countHighCards(myAllCards);
+  const lowPotential = hasLowPotential(myAllCards);
+  const opponentsHighOnly = allOpponentsHighOnly(seat, obs.players);
+
+  // スコア計算
+  const { highScore, lowScore } = calcHighLowScores(obs);
+  const combinedScore = calcStud8Score(obs);
+  const isScoopPotential = highScore >= 70 && lowScore >= 70;
+
+  // === 3rd Street ===
+  if (obs.street === "3rd") {
+    // ブリングインプレイヤー: 常にBRING_IN
+    if (isBringInPlayer && legal.includes("BRING_IN")) {
+      return "BRING_IN";
+    }
+
+    // ルール2: 3枚全て8以下ならCOMPLETE
+    if (isAll8OrBelow && legal.includes("COMPLETE")) {
+      return "COMPLETE";
+    }
+
+    // COMPLETE後の対応（currentBet > bringIn）
+    if (obs.currentBet > obs.stakes.bringIn) {
+      // 3枚全て8以下ならRAISEまたはCALL
+      if (isAll8OrBelow) {
+        if (legal.includes("RAISE") && rng() < 0.5) {
+          return "RAISE";
+        }
+        if (legal.includes("CALL")) return "CALL";
+      }
+
+      // ルール1: Low可能性があればCALL
+      if (lowPotential && legal.includes("CALL")) {
+        return "CALL";
+      }
+
+      // それ以外はFOLD
+      if (legal.includes("FOLD")) return "FOLD";
+    }
+
+    // bringInのみの状態：Low可能性があればCALL、なければFOLD
+    if (obs.currentBet === obs.stakes.bringIn) {
+      if (lowPotential && legal.includes("CALL")) {
+        return "CALL";
+      }
+      if (legal.includes("FOLD")) return "FOLD";
+    }
+  }
+
+  // === 4th Street 以降 ===
+
+  // currentBet == 0 の処理（CHECK / BET）
+  if (obs.currentBet === 0) {
+    // ルール4: 相手全員9+ならアグレッシブにBET
+    if (opponentsHighOnly && legal.includes("BET")) {
+      return "BET";
+    }
+
+    // ルール5: 5th以降でペアがあればやや強気でBET
+    if (isBigBetStreet(obs.street) && myHasPair && legal.includes("BET")) {
+      if (combinedScore >= 50 && rng() < 0.6) {
+        return "BET";
+      }
+    }
+
+    // ルール6: スクープ可能性が高ければBET
+    if (isScoopPotential && legal.includes("BET")) {
+      return "BET";
+    }
+
+    // 通常のBET判定
+    if (legal.includes("BET") && combinedScore >= 65) {
+      return "BET";
+    }
+
+    // CHECK
+    if (legal.includes("CHECK")) return "CHECK";
+  }
+
+  // currentBet > 0 の処理（CALL / RAISE / FOLD）
+  if (obs.currentBet > 0) {
+    // ルール3: ハイカード3枚以上でフォールド傾向強化
+    if (highCardCount >= 3) {
+      // Low可能性がもうない場合はFOLD傾向
+      if (!lowPotential && legal.includes("FOLD")) {
+        // ただしHighスコアが高ければ粘る
+        if (highScore < 60) {
+          return "FOLD";
+        }
+      }
+    }
+
+    // ルール4: 相手全員9+ならアグレッシブにRAISE
+    if (opponentsHighOnly) {
+      if (legal.includes("RAISE") && rng() < 0.7) {
+        return "RAISE";
+      }
+      if (legal.includes("CALL")) return "CALL";
+    }
+
+    // ルール6: スクープ可能性が高ければRAISE頻度UP
+    if (isScoopPotential && legal.includes("RAISE")) {
+      if (rng() < 0.6) {
+        return "RAISE";
+      }
+    }
+
+    // ルール5: 5th以降でペアがあればやや強気
+    if (isBigBetStreet(obs.street) && myHasPair) {
+      if (legal.includes("CALL")) return "CALL";
+    }
+
+    // ルール1: Low可能性があればCALL
+    if (lowPotential && legal.includes("CALL")) {
+      return "CALL";
+    }
+
+    // 通常のFOLD判定
+    if (legal.includes("FOLD") && combinedScore < 40) {
+      return "FOLD";
+    }
+
+    // CALL
+    if (legal.includes("CALL")) return "CALL";
+
+    // フォールバック: FOLD
+    if (legal.includes("FOLD")) return "FOLD";
+  }
+
+  // === フォールバック ===
+  if (legal.includes("CHECK")) return "CHECK";
+  if (legal.includes("CALL")) return "CALL";
+  if (legal.includes("BRING_IN")) return "BRING_IN";
+  if (legal.includes("FOLD")) return "FOLD";
+
+  return legal[0];
+};

--- a/test/domain/cpu/decideStud8Lv1.test.ts
+++ b/test/domain/cpu/decideStud8Lv1.test.ts
@@ -1,0 +1,430 @@
+import { describe, expect, it } from "vitest";
+import { decideStud8Lv1 } from "../../../src/domain/cpu/decideStud8Lv1";
+import type { CpuDecisionContext } from "../../../src/domain/cpu/policy";
+import type { Card, DealState } from "../../../src/domain/types";
+
+/**
+ * decideStud8Lv1 のテスト
+ * 6つの戦略ルールの検証
+ */
+describe("decideStud8Lv1", () => {
+  const createStud8State = (overrides: Partial<DealState> = {}): DealState => ({
+    dealId: "stud8-test",
+    gameType: "stud8",
+    playerCount: 2,
+    players: [
+      {
+        seat: 0,
+        kind: "human",
+        active: true,
+        stack: 900,
+        committedTotal: 30,
+        committedThisStreet: 20,
+      },
+      {
+        seat: 1,
+        kind: "cpu",
+        active: true,
+        stack: 990,
+        committedTotal: 10,
+        committedThisStreet: 0,
+      },
+    ],
+    seatOrder: ["player1", "player2"],
+    ante: 10,
+    bringIn: 20,
+    smallBet: 40,
+    bigBet: 80,
+    street: "3rd",
+    bringInIndex: 0,
+    currentActorIndex: 1,
+    pot: 40,
+    currentBet: 20,
+    raiseCount: 0,
+    pendingResponseCount: 1,
+    checksThisStreet: 0,
+    actionsThisStreet: [],
+    dealFinished: false,
+    deck: [],
+    rngSeed: "",
+    hands: {
+      0: {
+        downCards: [
+          { rank: "K", suit: "c" } as Card,
+          { rank: "Q", suit: "c" } as Card,
+        ],
+        upCards: [{ rank: "J", suit: "h" } as Card],
+      },
+      1: {
+        downCards: [
+          { rank: "A", suit: "h" } as Card,
+          { rank: "2", suit: "c" } as Card,
+        ],
+        upCards: [{ rank: "3", suit: "s" } as Card],
+      },
+    },
+    eventLog: [],
+    ...overrides,
+  });
+
+  describe("ルール1: Low可能性があればCALL", () => {
+    it("Low可能性がある時はFOLDせずCALLすること", () => {
+      const state = createStud8State({
+        street: "4th",
+        currentBet: 40,
+        hands: {
+          0: {
+            downCards: [
+              { rank: "K", suit: "s" } as Card,
+              { rank: "Q", suit: "s" } as Card,
+            ],
+            upCards: [
+              { rank: "J", suit: "h" } as Card,
+              { rank: "T", suit: "d" } as Card,
+            ],
+          },
+          1: {
+            downCards: [
+              { rank: "A", suit: "h" } as Card,
+              { rank: "4", suit: "c" } as Card,
+            ],
+            upCards: [
+              { rank: "5", suit: "s" } as Card,
+              { rank: "7", suit: "d" } as Card, // 4枚全て8以下 = Low可能性あり
+            ],
+          },
+        },
+      });
+
+      const ctx: CpuDecisionContext = {
+        state,
+        seat: 1,
+        allowedActions: ["CALL", "RAISE", "FOLD"],
+      };
+
+      const action = decideStud8Lv1(ctx);
+      expect(action).not.toBe("FOLD");
+      expect(["CALL", "RAISE"]).toContain(action);
+    });
+  });
+
+  describe("ルール2: 3rd全て8以下ならCOMPLETE", () => {
+    it("3rdで3枚全て8以下の場合COMPLETEを選択すること", () => {
+      const state = createStud8State({
+        street: "3rd",
+        currentBet: 20,
+        hands: {
+          0: {
+            downCards: [
+              { rank: "K", suit: "c" } as Card,
+              { rank: "Q", suit: "c" } as Card,
+            ],
+            upCards: [{ rank: "J", suit: "h" } as Card],
+          },
+          1: {
+            downCards: [
+              { rank: "A", suit: "h" } as Card,
+              { rank: "2", suit: "c" } as Card,
+            ],
+            upCards: [{ rank: "5", suit: "s" } as Card], // 全て8以下
+          },
+        },
+      });
+
+      const ctx: CpuDecisionContext = {
+        state,
+        seat: 1,
+        allowedActions: ["CALL", "FOLD", "COMPLETE"],
+      };
+
+      const action = decideStud8Lv1(ctx);
+      expect(action).toBe("COMPLETE");
+    });
+
+    it("ブリングインプレイヤーはBRING_INを選択すること", () => {
+      const state = createStud8State({
+        street: "3rd",
+        currentBet: 0,
+        bringInIndex: 1,
+        hands: {
+          0: {
+            downCards: [
+              { rank: "K", suit: "c" } as Card,
+              { rank: "Q", suit: "c" } as Card,
+            ],
+            upCards: [{ rank: "J", suit: "h" } as Card],
+          },
+          1: {
+            downCards: [
+              { rank: "A", suit: "h" } as Card,
+              { rank: "2", suit: "c" } as Card,
+            ],
+            upCards: [{ rank: "5", suit: "s" } as Card],
+          },
+        },
+      });
+
+      const ctx: CpuDecisionContext = {
+        state,
+        seat: 1,
+        allowedActions: ["BRING_IN", "COMPLETE"],
+      };
+
+      const action = decideStud8Lv1(ctx);
+      expect(action).toBe("BRING_IN");
+    });
+  });
+
+  describe("ルール3: ハイカード3枚以上でFOLD傾向", () => {
+    it("ハイカード(9+)が3枚以上でLow不可かつHighスコア低い場合FOLDすること", () => {
+      const state = createStud8State({
+        street: "5th",
+        currentBet: 80,
+        players: [
+          {
+            seat: 0,
+            kind: "human",
+            active: true,
+            stack: 800,
+            committedTotal: 200,
+            committedThisStreet: 80,
+          },
+          {
+            seat: 1,
+            kind: "cpu",
+            active: true,
+            stack: 850,
+            committedTotal: 150,
+            committedThisStreet: 0,
+          },
+        ],
+        hands: {
+          0: {
+            downCards: [
+              { rank: "A", suit: "s" } as Card,
+              { rank: "A", suit: "h" } as Card, // 強そう
+            ],
+            upCards: [
+              { rank: "A", suit: "c" } as Card,
+              { rank: "K", suit: "h" } as Card,
+              { rank: "Q", suit: "d" } as Card,
+            ],
+          },
+          1: {
+            downCards: [
+              { rank: "9", suit: "h" } as Card,
+              { rank: "T", suit: "c" } as Card, // ハイカードのみ、役なし
+            ],
+            upCards: [
+              { rank: "J", suit: "d" } as Card,
+              { rank: "Q", suit: "c" } as Card,
+              { rank: "K", suit: "s" } as Card, // 5枚全て9+、ハイカードのみ
+            ],
+          },
+        },
+      });
+
+      const ctx: CpuDecisionContext = {
+        state,
+        seat: 1,
+        allowedActions: ["CALL", "RAISE", "FOLD"],
+      };
+
+      const action = decideStud8Lv1(ctx);
+      // ハイカードのみでLow不可、Highも弱い → FOLD傾向
+      // ただしcombinedScoreが40以上ならCALLする可能性もある
+      expect(["CALL", "FOLD"]).toContain(action);
+    });
+  });
+
+  describe("ルール4: 相手upcard全員9+ならアグレッシブ", () => {
+    it("相手のupcardが全て9+の場合BETすること", () => {
+      const state = createStud8State({
+        street: "4th",
+        currentBet: 0,
+        hands: {
+          0: {
+            downCards: [
+              { rank: "K", suit: "s" } as Card,
+              { rank: "Q", suit: "s" } as Card,
+            ],
+            upCards: [
+              { rank: "J", suit: "h" } as Card,
+              { rank: "T", suit: "d" } as Card, // 全て9+
+            ],
+          },
+          1: {
+            downCards: [
+              { rank: "A", suit: "h" } as Card,
+              { rank: "2", suit: "c" } as Card,
+            ],
+            upCards: [
+              { rank: "5", suit: "s" } as Card,
+              { rank: "7", suit: "d" } as Card,
+            ],
+          },
+        },
+      });
+
+      const ctx: CpuDecisionContext = {
+        state,
+        seat: 1,
+        allowedActions: ["CHECK", "BET"],
+      };
+
+      const action = decideStud8Lv1(ctx);
+      expect(action).toBe("BET");
+    });
+
+    it("相手upcard全員9+でRAISE頻度が高まること", () => {
+      const state = createStud8State({
+        street: "4th",
+        currentBet: 40,
+        hands: {
+          0: {
+            downCards: [
+              { rank: "K", suit: "s" } as Card,
+              { rank: "Q", suit: "s" } as Card,
+            ],
+            upCards: [
+              { rank: "J", suit: "h" } as Card,
+              { rank: "T", suit: "d" } as Card,
+            ],
+          },
+          1: {
+            downCards: [
+              { rank: "A", suit: "h" } as Card,
+              { rank: "3", suit: "c" } as Card,
+            ],
+            upCards: [
+              { rank: "5", suit: "s" } as Card,
+              { rank: "7", suit: "d" } as Card,
+            ],
+          },
+        },
+      });
+
+      const ctx: CpuDecisionContext = {
+        state,
+        seat: 1,
+        allowedActions: ["CALL", "RAISE", "FOLD"],
+      };
+
+      // rng=0.5 < 0.7 なのでRAISE
+      const action = decideStud8Lv1(ctx, () => 0.5);
+      expect(action).toBe("RAISE");
+    });
+  });
+
+  describe("ルール5: 5th以降ペアでやや強気", () => {
+    it("5th以降でペアがある場合BET頻度が上がること", () => {
+      const state = createStud8State({
+        street: "5th",
+        currentBet: 0,
+        hands: {
+          0: {
+            downCards: [
+              { rank: "A", suit: "s" } as Card,
+              { rank: "K", suit: "s" } as Card,
+            ],
+            upCards: [
+              { rank: "Q", suit: "h" } as Card,
+              { rank: "J", suit: "d" } as Card,
+              { rank: "T", suit: "c" } as Card,
+            ],
+          },
+          1: {
+            downCards: [
+              { rank: "7", suit: "h" } as Card,
+              { rank: "7", suit: "c" } as Card, // ペア
+            ],
+            upCards: [
+              { rank: "5", suit: "s" } as Card,
+              { rank: "3", suit: "d" } as Card,
+              { rank: "A", suit: "c" } as Card,
+            ],
+          },
+        },
+      });
+
+      const ctx: CpuDecisionContext = {
+        state,
+        seat: 1,
+        allowedActions: ["CHECK", "BET"],
+      };
+
+      // ペア + Low可能性 + 相手全員9+ → BET
+      const action = decideStud8Lv1(ctx, () => 0.3);
+      expect(action).toBe("BET");
+    });
+  });
+
+  describe("ルール6: スクープ可能性高時RAISE頻度UP", () => {
+    it("High/Low両方強い場合RAISE頻度が上がること", () => {
+      const state = createStud8State({
+        street: "5th",
+        currentBet: 80,
+        hands: {
+          0: {
+            downCards: [
+              { rank: "K", suit: "c" } as Card,
+              { rank: "Q", suit: "c" } as Card,
+            ],
+            upCards: [
+              { rank: "J", suit: "h" } as Card,
+              { rank: "T", suit: "d" } as Card,
+              { rank: "9", suit: "s" } as Card,
+            ],
+          },
+          1: {
+            downCards: [
+              { rank: "A", suit: "h" } as Card,
+              { rank: "2", suit: "h" } as Card,
+            ],
+            upCards: [
+              { rank: "3", suit: "h" } as Card,
+              { rank: "4", suit: "h" } as Card,
+              { rank: "5", suit: "h" } as Card, // フラッシュドロー + A-5ロー可能性
+            ],
+          },
+        },
+      });
+
+      const ctx: CpuDecisionContext = {
+        state,
+        seat: 1,
+        allowedActions: ["CALL", "RAISE", "FOLD"],
+      };
+
+      // スクープ可能性高 + rng < 0.6 → RAISE
+      const action = decideStud8Lv1(ctx, () => 0.4);
+      expect(action).toBe("RAISE");
+    });
+  });
+
+  describe("合法性テスト", () => {
+    it("返すアクションがallowedActionsに含まれていること", () => {
+      const state = createStud8State();
+      const ctx: CpuDecisionContext = {
+        state,
+        seat: 1,
+        allowedActions: ["CALL", "RAISE", "FOLD"],
+      };
+
+      const action = decideStud8Lv1(ctx, () => 0.5);
+      expect(["CALL", "RAISE", "FOLD"]).toContain(action);
+    });
+
+    it("allowedActionsが1つの場合そのアクションを返すこと", () => {
+      const state = createStud8State();
+      const ctx: CpuDecisionContext = {
+        state,
+        seat: 1,
+        allowedActions: ["CALL"],
+      };
+
+      const action = decideStud8Lv1(ctx);
+      expect(action).toBe("CALL");
+    });
+  });
+});


### PR DESCRIPTION
## 概要

Stud8のCPU Lv1戦略を改善し、High/Low両面を考慮した合理的な意思決定ロジックを実装しました。

Closes #97

## 変更内容

### 新規ファイル
- `src/domain/cpu/decideStud8Lv1.ts` - Stud8専用CPU戦略
- `test/domain/cpu/decideStud8Lv1.test.ts` - テストケース10件

### 変更ファイル
- `src/domain/cpu/decideLv1.ts` - Stud8の場合に専用戦略へ分岐

## 実装した戦略ルール

| # | ルール名 | 内容 |
|---|----------|------|
| 1 | **Low可能性CALLルール** | Low完成可能性がある時はフォールドせずコール |
| 2 | **3rd強スタートルール** | 3rdで3枚全て8以下ならCOMPLETE |
| 3 | **High偏重FOLDルール** | ハイカード(9+)が3枚以上でLow不可ならフォールド傾向 |
| 4 | **Low独占AGGROルール** | 相手upcard全員9+ならアグレッシブにプレイ |
| 5 | **ペア発生強気ルール** | 5th以降でペアができたらやや強気 |
| 6 | **スクープRAISEルール** | High/Low両方スコア70+でRAISE頻度UP |

## 検証結果

```
✓ npm run lint - Checked 86 files, No errors
✓ npm run format - Formatted 84 files
✓ npm run test - 15 files, 213 tests passed
```