### PR TITLE
#99 feat: Stud Hi CPU Lv2戦略を実装

### DIFF
--- a/.agent/rules/general_rule.md
+++ b/.agent/rules/general_rule.md
@@ -20,3 +20,4 @@ description: Use existing rules for this project
 ## ルールの適用
 
 `general.md` を読み込んだ後、その指示に従って、タスクの内容に応じた追加のルールファイル（例：`implementation.md`, `requirements.md` など）を自律的に読み込んで適用してください。
+タスクを進める上で不明点がや曖昧な点があれば必ずユーザに確認してください。

--- a/docs/cpu_Lv2/Razz_実装指示書.md
+++ b/docs/cpu_Lv2/Razz_実装指示書.md
@@ -1,0 +1,327 @@
+# Razz CPU戦略 Lv2 実装指示書（ルールベース / 強め）
+Version: 1.0  
+Target: 7 Card Stud Low（Razz）  
+目的: ルールベースで「強い」CPU（Lv2）を実装する。特に 3rd のスチール/リスチール、dead cardsの反映、5th以降のフォールド最適化、7thのオーバーフォールド回避を重視する。  
+制約: CPUは `allowedActions` の範囲でアクション種別を返す。金額計算はエンジン側。  
+
+---
+
+## 0. 前提（入力・見える情報）
+
+### 0.1 入力（既存CPUインターフェース想定）
+- `state: DealState`
+- `seat: SeatIndex`
+- `allowedActions: EventType[]`
+
+### 0.2 見えるカード情報
+- 自分: `state.hands[seat].downCards + upCards` が見える
+- 相手: `upCards` のみ見える
+- dead cards（公開情報で確定して見えているカード）
+  - **自分以外の全プレイヤーの upCards（fold済み含む）**を dead とする  
+  - downCards は見えないので dead に含めない
+
+---
+
+## 1. 中間表現（VisibleContext）— Stud Hiと共通でOK
+
+### 1.1 型（推奨）
+```ts
+export type LiveGrade = "GOOD" | "OK" | "BAD";
+
+export interface VisiblePlayer {
+  seat: number;
+  active: boolean;
+  up: Card[];
+  downCount: number;
+}
+
+export interface VisibleContext {
+  street: Street;
+  me: { seat: number; up: Card[]; down: Card[] };
+  opponents: VisiblePlayer[];
+  aliveSeats: number[];
+  headsUp: boolean;
+
+  deadUpCards: Card[];
+  deadRankCount: Record<Rank, number>; // 相手upのrank枚数
+  deadSuitCount: Record<Suit, number>;
+
+  bringInSeat: number;
+}
+```
+
+### 1.2 buildVisibleContext（Stud版と同一でOK）
+- `deadUpCards = opponents.flatMap(o => o.up)`
+- `headsUp = aliveSeats.length === 2`
+
+---
+
+## 2. Razz専用：Low評価の基礎定義
+
+### 2.1 Lowのランク値（Aが最強のロー＝1）
+```ts
+export const LOW_VALUE: Record<Rank, number> = {
+  "A": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8,
+  "9": 9, "T": 10, "J": 11, "Q": 12, "K": 13,
+};
+export const lowValue = (r: Rank): number => LOW_VALUE[r];
+```
+
+### 2.2 「良いロー」の比較
+- Razzは **5枚のロー（ペアは悪い）**を作るゲーム。
+- 実装では、以下の2種類のスコアを使い分ける。
+
+#### (A) BoardPotentialScore（ボード＋自分ダウンでの到達可能性）
+- 4th〜6thの「エクイティリーダー」判断に使う  
+- 厳密な最良5枚計算は不要。  
+- **“今見えている低カードの質”**と**“ペア汚染の有無”**を評価する。
+
+#### (B) ShowdownLowScore（7thでの完成ロー比較）
+- 役判定設計書に low 判定（`LowHandScore { ranks: number[] }`）があるならそれを使用する（最優先）。
+- 既存が無い場合のみ簡易実装を用意（後述）。
+
+---
+
+## 3. Razz専用：dead cardsの重み付け（Lv2の核）
+
+### 3.1 重要カード（Key Low Cards）
+- A/2/3/4/5 は特に重要（“車輪”周辺）
+- 6/7/8 も重要だが優先度は下げる
+- 9以上は「ブリック」「スチール材料」など別用途
+
+### 3.2 dead の評価ルール（概算でOK、ただし一貫性が重要）
+- **欲しい低カードが dead に出ているほどマイナス**
+  - A〜5: 1枚deadごとに重く（例：-2.0点）
+  - 6〜8: 1枚deadごとに中（例：-1.0点）
+- **自分のペアを誘発するランクが dead に出ているほどプラス**  
+  - 例：自分が 4 を複数持っている/持ちやすい状況で、相手upに 4 が多い → 将来の“被り”リスク低下
+
+> Lv2では「低カードのdeadを必ず参照し、3rd参加判断・5th以降継続判断に反映」すること。
+
+---
+
+## 4. 3rdストリート（Lv2の最重要：ドアカード×競合×手札質×dead）
+
+### 4.1 3rdの分類（実装がブレないよう固定）
+- Door = `me.up[0]`（3rdの唯一のup）
+- “低いドアが強い”ゲーム（Aが最強）
+- 競合 = “後ろに 8以下のドアがいる人数” を基本指標にする
+
+### 4.2 3rdのハンド品質判定（最小だが強い）
+以下は `me.down + me.up` の3枚で判定。
+
+#### 強い3枚（Monster3）
+- 例：A23 / A24 / 234 / A25 など
+- 条件（簡易）：
+  - 3枚すべて 5以下 かつ 全部別ランク（ノーペア）
+
+#### 標準参加（Good3）
+- ルールの軸：「8以下3種3枚」
+- 条件：
+  - 3枚すべて 8以下 かつ 全部別ランク（ノーペア）
+
+#### 条件付き（Okay3）
+- 3枚のうち 2枚が 8以下（別ランク）で、残りが 9以下程度
+- または 8以下3枚だがペア含み（被り）で弱体化
+
+#### 弱い（Bad3）
+- 3枚で9以上が混ざる、ペアがある、A/2/3が少ない、deadが悪い 等
+
+### 4.3 3rd：競合数カウント（BehindCompetitors）
+- “後ろ”の定義：**今後アクションするプレイヤー**
+- seat順の扱い：
+  - 基本はエンジン側の進行に依存するため、簡易に「未行動 = committedThisStreet==0 かつ active」等で推定するか、
+  - もしくは「全員のドア比較」で近似しても良い（Lv2では推奨しないが許容）
+- 最低限の実装指示：
+  - 3rd時点で `opponents` の door（up[0]）を取り、**自分より“強い（＝より低い）ドア”がいる人数**を競合とする  
+  - ただし「後ろ」概念は精度に効くので、可能なら eventLog からアクション順を復元する（付録参照）
+
+### 4.4 3rd：意思決定ルール（Complete/Call/Fold + 対3bet）
+
+#### 3rd-1: 自分がBring-in担当（BRING_IN or COMPLETE）
+- Monster3 / Good3 / Okay3 → **COMPLETE**
+- Bad3 → **BRING_IN**（最小で様子見。相手がcompleteしてきたら基本FOLD）
+
+#### 3rd-2: 通常オープン（まだcompleteされていない局面）
+**A. Doorが 9以上（= 高いドアで弱い）**
+- 自分より“低いドア”が相手にいる → **FOLD**
+- 全員が自分より“高いドア”（＝相手の方が悪い） → **COMPLETE（Any2スチール）**
+  - ただし、deadで相手の低カードが極端に死んでいる（A〜5が多く死んでいる）場合はスチール成功率が上がるので、より積極的にCOMPLETE
+
+**B. Doorが 8以下（= 良いドア）**
+- 競合（低いドアの相手）が 2人以上：
+  - Good3以上 → **COMPLETE**
+  - Okay3以下 → **FOLD**
+- 競合が 1人：
+  - “8以下が2枚以上（別ランク）” → **COMPLETE**
+  - それ以外 → **FOLD**
+- 競合が 0人（全員9以上）：
+  - ハンド中身に関わらず **COMPLETE（スチール）**
+  - ただし“ドアが8以下で競合0”は超有利なので、以降ストリートも強く継続（後述）
+
+#### 3rd-3: 相手のCOMPLETEに直面（CALL/RAISE/FOLD）
+- 基本思想：Razzは「良いドア×良い3枚」で戦う。弱いドアでの守備は“相手がスチール濃厚”のときだけ。
+- まず相手がスチールっぽいか判定：
+  - 相手ドアが 9以上 かつ 自分ドアがそれより低い（= 相手がAny2スチールの典型）→ “StealLikely”
+  - 相手ドアが 8以下 → “TightLikely” （本物レンジ寄り）
+
+**応答ルール**
+- TightLikely（相手ドア8以下）：
+  - Good3以上 → **CALL**
+  - Monster3 かつ 自分ドアが相手より低い → **RAISE（3bet）**
+  - Okay3以下 → **FOLD**
+- StealLikely（相手ドア9以上）：
+  - Okay3以上 → **CALL（広めに守る）**
+  - Monster3 / Good3 かつ deadが良い（A〜5が生きている）→ **RAISE**
+  - Bad3 → **FOLD**
+
+#### 3rd-4: 3bet返し（相手が再レイズしてきた）
+- Lv2では戦争を限定する（ミスを減らして強く見える）
+- **CALLで続行してよい条件**：
+  - Monster3（5以下3枚ノーペア）  
+  - または Good3 かつ 自分ドアが相手ドアより低い（優位）  
+- それ以外は **FOLD**
+
+#### 3rd-5: HUトラップ（任意。実装優先度は低め）
+- headsUp かつ 自分が超強い（Monster3）かつ 自分が“アクション最後”でポットを膨らませる必要が薄い場合：
+  - COMPLETEせず **CALL** に留める選択を許可（ただし頻度は低くてよい）
+
+---
+
+## 5. 4th〜6th（主導権：Equity Leader / Brick / Pair汚染 / dead）
+
+### 5.1 “Brick（ブリック）”定義
+- 9以上を引く、または自分の既存ランクと被ってペア汚染するカードを引く、など  
+（厳密でなくてよい。判断が一貫していることが重要）
+
+### 5.2 ボード強弱の簡易指標（BoardLowQuality）
+4th以降の自分の見えているカード（downも含めて良い）から、以下を数える：
+
+- `lowCount8 = # { cards with value <= 8 }`
+- `pairPenalty = 同ランクの重複数`（例：同rankが2枚なら+1、3枚なら+2…）
+- `highCount = # { cards with value >= 9 }`
+
+これを使って “良い/普通/悪い” を分類する。
+
+### 5.3 Equity Leaderの原則（簡易で強い）
+以下のとき、自分が主導権を取りやすい（BET/RAISE）：
+- 自分のupボード（公開カード）が相手より明確に良い（低い）
+  - 例：自分 up が (A,3,5) っぽく、相手 up が (8,9,T) っぽい
+- 相手upがペアっぽい（同rankがupで重なる） or 相手にブリックが混ざっている
+- deadにより相手の有効牌（A〜5）が多く死んでいる
+
+### 5.4 4th：意思決定（CHECK/BET/CALL/RAISE/FOLD）
+**4th-1: 自分がベット可能**
+- 自分ボードが良い（lowCount8が増えた、ペア汚染なし）→ **BET**
+- 相手ボードが悪化（ブリック/ペア/高牌）→ **BET**
+- 自分がブリック + 相手が改善（相手upがA2系に寄る）→ **CHECK** 寄り
+
+**4th-2: 相手BETに直面**
+- 原則 **CALL**（4thは降りすぎない）
+- ただし例外FOLDを許可（Lv2の現実的損切り）：
+  - 自分が **連続ブリック**（この時点で高牌が2枚以上）かつ
+  - 相手のupが **A/2/3中心で改善** かつ
+  - deadが悪い（A〜5が多く死んでいる）  
+  → **FOLD**
+
+**4th-3: RAISE条件**
+- 自分が明確にEquity Leader（自分upが相手upより強いローに向かう）かつ
+- 相手がスチールっぽい/ブリック混入
+→ **RAISE**（ただし乱用しない）
+
+### 5.5 5th/6th：意思決定（Big Betなので分岐を強く）
+**5th/6th-1: 自分がベット可能**
+- 自分がEquity Leader → **BET**（ノースロープレイ）
+- 相手のupがペア/ブリック多め → **BET**
+- 自分がブリック + 相手が改善 + dead悪い → **CHECK**（可能なら）
+
+**5th/6th-2: 相手BETに直面（CALL/FOLDが最重要）**
+- CALLしてよい条件（いずれか満たせばCALL）：
+  1) 自分の“低牌の枚数”が十分（例：<=8が4枚以上）で、ペア汚染が軽い  
+  2) 相手upがブリック/ペアで弱い（相手の完成率が低い）  
+  3) deadが相手不利（A〜5が死んでいる）  
+- FOLD条件（いずれか強く該当でFOLD）：
+  - 自分が 5th/6thで **ブリック連発**（>=9が2枚以上、かつ低牌が増えない）
+  - 相手upが **非常に良い**（A〜5が多く、ペアも見えない）
+  - deadが **自分に不利**（A〜5が大量に死んでおり、自分の改善が薄い）
+
+> Lv2では「5thで弱い継続を切れる」ことが強さの核。  
+> ただしRazzは7thで逆転もあり、相手ボードが汚いなら粘る。
+
+---
+
+## 6. 7th（オーバーフォールド回避：ベット/ブラフキャッチを強めに）
+
+### 6.1 7thの前提
+- 相手の7thは見えないため、6thまでのボードとラインで推測する
+- 7thは「降りすぎ」が最大リークなので、Lv2は **一定条件で必ずコール** を組み込む
+
+### 6.2 7th：バリューベット（相手がチェック）
+- 自分が “十分良いロー” と判断できるなら **BET**
+  - 目安（簡易）：
+    - 自分の最良5枚の最大カードが 8以下（= 8ロー相当） → ほぼBET
+    - 9ロー相当でも、相手upが汚い（高牌/ペア多い）ならBET
+- さらに “相手が極端に汚いボード” の場合：
+  - 自分が弱め（Tロー/Kロー相当）でも **BET** を許可（ブリック相手への押し切り/薄いバリュー）
+
+### 6.3 7th：相手BETに直面（CALL/FOLD）
+CALLしやすい条件（2つ以上でCALL推奨、HUなら1つでもCALL可）：
+1) 相手upが汚い（9以上が複数 / 明確なブリック）  
+2) 相手upにペア要素がある、またはdead状況からペアが疑わしい  
+3) 相手が6th時点で“未完成っぽい”（upがA〜5中心でない、連続改善が見えない）  
+4) 自分が少なくとも “9ロー相当” 以上の完成が見込める
+
+FOLD推奨：
+- 相手upが極めて良い（A〜5が多く、ペア無し、ブリック無し）かつ
+- 自分が明確に悪い（ブリック多い/ペア汚染）  
+→ FOLD
+
+> Lv2の重要仕様：
+> - 「相手はローが出来ていれば高頻度でBETしてくる」前提で、
+> - 相手が未完成だった可能性が高いなら、一定割合で必ずCALLしてオーバーフォールドを防ぐ。
+
+---
+
+## 7. allowedActions フォールバック規則（共通）
+- 望ましい行動が無ければ次善へ落とす
+  - RAISE → CALL
+  - BET → CHECK
+  - CALL → CHECK（あれば）/ それも無ければ FOLD
+  - BRING_IN局面は BRING_IN / COMPLETE の二択なので必ず決められる
+
+---
+
+## 8. 実装タスク（AIへの具体指示）
+
+### 8.1 必須関数（最低限）
+- `buildVisibleContext(state, seat)`（Studと共通）
+- `lowValue(rank)`（A=1）
+- `eval3rdQuality(me3): Monster3/Good3/Okay3/Bad3`
+- `countDeadLow(deadRankCount)`：
+  - A〜5のdead枚数、6〜8のdead枚数
+- `estimateBoardQuality(cards)`：
+  - lowCount8, highCount9, pairPenalty
+- `isStealLikely(opDoor, myDoor)`：
+  - opDoor >= 9 & myDoor < opDoor など簡易で良い
+- `scoreOppBoardDirt(opUpCards)`：
+  - 高牌の多さ、ペアの有無
+
+### 8.2 推奨（強さが上がる）
+- `getLastAggressorSeat(state.eventLog, state.street)`：
+  - 直近の BRING_IN / COMPLETE / BET / RAISE の seat を取得し、
+  - 4th〜7thで主導権（Aggressor/Defender）を判定に使う
+
+---
+
+## 9. テスト観点（最低限）
+- 3rd分岐：
+  - Door>=9 かつ後ろに低ドアあり → FOLD
+  - Door>=9 かつ全員高ドア → COMPLETE
+  - Door<=8 で競合2人以上、Good3未満 → FOLD
+  - Bring-inでBad3 → BRING_IN、Good3以上 → COMPLETE
+- 5th/6thの損切り：
+  - ブリック連発 + 相手良ボード + dead不利 → FOLD
+- 7thのオーバーフォールド回避：
+  - 相手up汚い＆未完成推定 → 弱めローでもCALLが選ばれる
+
+---

--- a/docs/cpu_Lv2/Stud8_実装指示書.md
+++ b/docs/cpu_Lv2/Stud8_実装指示書.md
@@ -1,0 +1,301 @@
+# Stud8 CPU戦略 Lv2 実装指示書（ルールベース / 強め）
+Version: 1.0  
+Target: 7 Card Stud Hi-Lo Eight-or-better（Stud8）  
+目的: ルールベースで「強い」CPU（Lv2）を実装する。3rdの参加/スチール、dead cards反映、4th〜6thの構図（Hi-Hi / Hi-Lo / Lo-Lo）分岐、Scoop最大化とQuarter回避、7thのオーバーフォールド回避を重視する。  
+制約: CPUは `allowedActions` の範囲でアクション種別を返す。金額計算はエンジン側。  
+
+---
+
+## 0. 前提（入力・見える情報）
+
+### 0.1 入力
+- `state: DealState`
+- `seat: SeatIndex`
+- `allowedActions: EventType[]`
+
+### 0.2 見えるカード
+- 自分: `state.hands[seat].downCards + upCards`
+- 相手: `upCards` のみ
+- dead cards: **自分以外の全プレイヤーの upCards（fold済み含む）**
+  - Lowのdead（A〜8）は影響が大きいので必ず参照
+
+---
+
+## 1. 中間表現（VisibleContext）— StudHi / Razzと共通でOK
+Stud8でも `buildVisibleContext()` は共通実装でよい。
+
+```ts
+export interface VisibleContext {
+  street: Street;
+  me: { seat: number; up: Card[]; down: Card[] };
+  opponents: { seat: number; active: boolean; up: Card[]; downCount: number }[];
+  aliveSeats: number[];
+  headsUp: boolean;
+  deadUpCards: Card[];
+  deadRankCount: Record<Rank, number>;
+  deadSuitCount: Record<Suit, number>;
+  bringInSeat: number;
+}
+```
+
+---
+
+## 2. Stud8専用：評価軸（Hi / Lo / Scoop）
+
+### 2.1 2つの“資格”を分けて扱う（重要）
+- **Lo資格（Low Qualify）**: 8以下の5枚ローが作れる見込みがあるか
+- **Hi資格（High Contend）**: ペア以上・強ドロー等でハイを取りにいけるか
+
+### 2.2 “Scoop可能性”を実装で扱える形に落とす
+Stud8の強さは「Scoop狙い」と「Quarter回避」に集約される。Lv2では以下の3段階に分類する。
+
+- `SCOOP`：HiもLoも取りにいける（A2x, A3x + ペア等）
+- `FREEROLL`：自分が片方（多くはLo）を強く持ち、もう片方も勝てる可能性がある
+- `SPLIT`：片方しか現実的に狙えない（Lo-only / Hi-only）
+
+### 2.3 dead cards の扱い（Lowは重く、Highは中）
+- Low狙い: A〜8のdead枚数が増えるほど評価を大きく下げる
+  - A〜5: 1枚deadごとに重い（例：-2点）
+  - 6〜8: 1枚deadごとに中（例：-1点）
+- High狙い: 自分のペアランクやフラ/ストレの鍵がdeadなら下げる（StudHiに準ずる）
+
+---
+
+## 3. Stud8専用：基本関数（実装AIが作るべき最小セット）
+
+### 3.1 Low用 rankValue（A=1）
+```ts
+export const LOW_VALUE: Record<Rank, number> = {
+  "A": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8,
+  "9": 9, "T": 10, "J": 11, "Q": 12, "K": 13,
+};
+```
+
+### 3.2 3rd品質分類（Stud8用）
+3rdの自分3枚（down2+up1）を以下で分類する。※“HiとLoの両睨み”を強く評価する。
+
+- `Scoop3_Monster`：
+  - A2x（x<=8）かつ 3枚すべて別ランク
+  - A3x（x<=8）かつ 3枚別ランク
+  - 低いペア＋低札（例：33A / 44A / 55A など）※Hi/Lo両面
+- `Low3_Good`：
+  - 8以下3枚別ランク（= 3-low）
+  - Aを含む 8以下2枚 + 9以下1枚（A持ち優遇）
+- `High3_Good`：
+  - 99+ のペア（Stud8でもハイが強い）
+  - 隠れハイペア（down-downが99+）
+  - 強い3フラ/3ストレ（ただしLo札が2枚以上なら加点）
+- `Marginal`：
+  - 片方のみ薄い（Lo札が2枚だけ、または弱いペアのみ等）
+- `Trash`：
+  - LoもHiも薄く、deadも悪い
+
+### 3.3 Opponent意図推定（Door card）
+- door = 相手 `up[0]`（3rd）
+- `door <= 8`：Lo志向（ただし“8以下3枚”である確率は高くない）
+- `door >= 9`：Hi志向 or Steal志向
+
+---
+
+## 4. 3rdストリート（最重要：参加・スチール・対コンプリート）
+
+### 4.1 3rdの基本思想（Lv2）
+- **Scoop3_Monster は最優先で攻撃（COMPLETE/3bet可）**
+- Lo-only同士のエクイティ差は小さいので、**Lo3_Good は降りすぎない**
+- Hi-onlyは “人数を減らす” 価値が高い（Scoopされると死ぬ）ので、強いときだけ戦う
+- スチールは行うが、**Lo志向のドアが残っていると成功しにくい**ため条件化する
+
+### 4.2 3rd：Bring-in担当（BRING_IN / COMPLETE）
+- Scoop3_Monster / Low3_Good / High3_Good → **COMPLETE**
+- Marginal → 盤面次第（後ろが弱いならCOMPLETE、強いLoドアが多いならBRING_IN）
+- Trash → **BRING_IN**
+
+### 4.3 3rd：通常オープン（まだcompleteされていない局面）
+#### 4.3.1 スチール条件（COMPLETE）
+- 自分のドアが **8以下**（Loを見せている）  
+  かつ
+- 後ろに “明確に強いLoドア（A/2/3）” がいない  
+  かつ
+- 後ろに 8以下ドアが少ない（<=1人）  
+→ ハンド中身がMarginalでも **COMPLETE（スチール）**
+
+※ Loドアでスチールすると「相手がHiで守りにくい」ので価値が高いが、A/2/3が残っていると反撃されやすい。
+
+#### 4.3.2 ハンド品質別
+- Scoop3_Monster → **COMPLETE（優先）**
+- Low3_Good → 競合Loドアが多くても **COMPLETE寄り**（降りすぎ防止）
+- High3_Good → 相手にLoドアが多い場合は **参加を絞る**（Scoopリスク）
+- Marginal → スチール条件を満たすときのみCOMPLETE、基本FOLD
+- Trash → FOLD
+
+### 4.4 3rd：相手COMPLETEに直面（CALL/RAISE/FOLD）
+相手ドアで相手レンジを分類する。
+
+- 相手ドア <= 8 → “Lo寄り”
+- 相手ドア >= 9 → “Hi/Steal寄り”
+
+**応答ルール**
+- 自分が Scoop3_Monster：
+  - 相手ドア <= 8 でも **CALL/RAISE**（deadが良ければRAISE）
+- 自分が Low3_Good：
+  - 相手ドア <= 8 → **CALL**（降りすぎ防止）
+  - 相手ドア >= 9 → **CALL**（相手がSteal寄りなら守る）
+- 自分が High3_Good：
+  - 相手ドア <= 8 → 原則FOLD（Scoopされる危険が高い）
+  - 相手ドア >= 9 → CALL（または自分が99+等ならRAISE）
+- Marginal/Trash → 基本FOLD（ただし相手が露骨スチールで自分ドアが良いならCALL）
+
+### 4.5 3rd：3bet返し（相手再レイズ）
+- 継続してよいのは以下のみ（強め損切りでLv2らしくする）
+  - Scoop3_Monster → CALL
+  - 99+ など強いHiペアで、相手ドアがHi寄り（>=9） → CALL
+  - Low3_Good でも deadが非常に良く、相手がSteal濃厚 → CALL（頻度低）
+- それ以外 → FOLD
+
+---
+
+## 5. 4th〜6th（構図判定→目標→アクション）
+
+### 5.1 構図（MatchupType）を毎ストリート推定する
+各プレイヤーについて「Lo志向 / Hi志向 / Scoop志向」を推定し、現在の主要対戦相手（最もアクティブに戦っている相手）との構図を分類する。
+
+- `HI_HI`：両者がハイ寄り
+- `HI_LO`：一方がハイ、もう一方がロー寄り
+- `LO_LO`：両者がロー寄り
+- `SCOOP_RACE`：どちらもScoop狙いの可能性（A2系が見える等）
+
+※ 主要対戦相手の選び方（簡易）：
+- activeの相手のうち、upが最も強く見える（Loなら低い、Hiならペア/高札）相手を選ぶ
+
+### 5.2 自分の現在地（Role）を3分類
+- `SCOOPING`：HiもLoも現実的
+- `LO_ONLY`：Loは現実的、Hiは薄い
+- `HI_ONLY`：Hiは現実的、Loは薄い
+- `AIR`：どちらも薄い（継続は相手の汚さ次第）
+
+### 5.3 4th（small bet）：降りすぎない
+**4th-1: 自分がBET可能**
+- SCOOPING → **BET**
+- HI_ONLY vs LO相手（HI_LO構図） → **BET**（相手を降ろしやすい / deny equity）
+- LO_ONLY → 相手がHiでボード強いならCHECK寄り、相手が汚いならBET
+- AIR → CHECK
+
+**4th-2: 相手BETに直面**
+- 原則CALL（4thは降りすぎない）
+- 例外FOLD（明確に不利でスクープされやすい）：
+  - 自分が HI_ONLY で、相手がLo完成に向かって強く見える（A2xが露骨）かつ
+  - deadがLoに有利（相手側のA〜5が生きている）  
+  → FOLD許可（頻度は低め）
+
+### 5.4 5th/6th（big bet）：目標を固定し分岐を強く
+5th以降は「コール＝高コスト」なので、Lv2では“スクープされる側の不利継続”を切る。
+
+#### 5th/6th-1: 自分がBET可能（基本）
+- SCOOPING → **BET/RAISE**（ノースロープレイ）
+- HI_ONLY（対LO） → **BET**（相手のLo未完成のうちは圧。相手がLo完成しそうでも打つ）
+- LO_ONLY（対HI） → 原則CALL寄り。BETは
+  - 相手Hiが弱そう（ペア気配なし/ブリック）で、Loがほぼ確定する時のみ
+- LO_LO → 自分のLoの“生き具合”が相手より良い（deadが有利/相手がブリック）ならBET
+
+#### 5th/6th-2: 相手BETに直面（CALL/FOLDの核）
+**CALL優先条件（いずれか）**
+- 自分がSCOOPING（片方だけでも取り切る見込みが高い）
+- 自分がLO_ONLYだが、相手のLoが汚い（ブリック/ペア/9以上混入）または deadが相手不利
+- 自分がHI_ONLYだが、相手のLoが未完成っぽい＆自分が強いハイ（TwoPair+相当見込み）
+
+**FOLD条件（強め損切り）**
+- 自分がHI_ONLYで、相手がLo確定級（ボードで8以下が揃い過ぎ）かつ 自分ハイも中程度以下
+  - → “相手にLoを取られ、Hiも競れない”＝スクープ/3/4取られが濃厚なので切る
+- 自分がLO_ONLYで、相手がHi確定級（オープンペア/Tripsの気配）かつ 自分Loがdeadで枯れている
+  - → “Quarter（ローを分ける）すら怪しい”ので切る
+
+> Lv2の重要仕様：
+> - 「Lo-onlyで相手Hi強＆Lo枯れ」の継続を強く切る  
+> - 「Hi-onlyで相手Lo強＆自分Hi弱」の継続を強く切る  
+> これが“強いStud8 CPU”の体感に直結する。
+
+---
+
+## 6. 7th（ブラフ抑制・オーバーフォールド回避・Quarter回避）
+
+### 6.1 7th：ベット方針（相手がチェック）
+- SCOOPING：
+  - 原則BET（バリュー）
+- LO_ONLY：
+  - Loが確定・強い（8ロー相当以上）ならBET（バリュー）
+  - ただし相手がHi強そうなら「ベットしてもコールされて半分」→ それでも基本BET（取りこぼし回避）
+- HI_ONLY：
+  - 相手がLo強そうならOOPはCHECK寄り（相手のLoがベットしてきたら判断）
+  - HUや相手が汚い場合は薄いBETを許可
+
+### 6.2 7th：相手BETに直面（CALL/FOLD）
+Stud8は“片方だけでも取れればコールが正当化されやすい”。Lv2ではオーバーフォールドを避ける。
+
+**CALL推奨（2つ以上でCALL、HUなら1つでCALL）**
+1) 相手ボードがLoに見えても、dead状況からLoが割れている/汚れている可能性が高い  
+2) 自分が少なくとも片方（Hi or Lo）を取る見込みがある  
+3) 相手がLo-onlyっぽいのに、こちらのHiが少しでもあり得る（ペア見込み等）  
+4) 相手がHi-onlyっぽいのに、こちらのLoが少しでもあり得る（8以下の枚数が足りている）
+
+**FOLD推奨**
+- 相手がSCOOP濃厚（ボードがA2系で綺麗）かつ 自分が両方薄い（AIR）  
+- または 自分が明確に“どちらも取れない”と推定できる場合
+
+### 6.3 ブラフ方針（重要：原則禁止、例外のみ）
+- LO_ONLYが外した（Lo未完成）状態での純ブラフは原則しない
+- 例外的に許可する条件（すべて満たす場合のみ）：
+  - 相手のupにSDVが見えない（ペア/高札がなく、Hiが弱そう）
+  - 自分のボードが“Loを狙っていたが外した”ように見える（自然な失敗ドロー）
+  - HU or 相手がタイト傾向（※本実装では個体差が無いならHU限定で良い）
+→ このときのみBETを許可
+
+---
+
+## 7. dead cards の具体反映（Low中心）
+### 7.1 Low deadスコア（簡易）
+- deadAto5 = deadRankCount[A..5] 合計
+- dead6to8 = deadRankCount[6..8] 合計
+- `lowDeadPenalty = 2*deadAto5 + 1*dead6to8`
+
+これを
+- 3rdのLow3_Good / Scoop3_Monster の強さ調整
+- 5th/6thの継続判断（LO_ONLYのCALL/FOLD）
+に必ず使う。
+
+---
+
+## 8. allowedActions フォールバック（共通）
+- RAISEが無い → CALL
+- BETが無い → CHECK
+- CALLが無い → CHECK（あれば）/ それも無ければ FOLD
+- BRING_IN局面は BRING_IN / COMPLETE の二択
+
+---
+
+## 9. 実装タスク（AIへの具体指示）
+
+### 9.1 必須
+- `buildVisibleContext(state, seat)`（共通）
+- `lowValue(rank)`（A=1）
+- `classify3rdStud8(me3)` → {Scoop3_Monster, Low3_Good, High3_Good, Marginal, Trash}
+- `countLowDead(deadRankCount)` → deadAto5, dead6to8, penalty
+- `inferIntentFromDoor(rank)` → "LO" | "HI"
+- `inferRoleNow(meCards)` → "SCOOPING" | "LO_ONLY" | "HI_ONLY" | "AIR"
+- `pickAction(allowed, prefs)`（共通）
+
+### 9.2 推奨（強くなる）
+- `getLastAggressorSeat(eventLog, street)` を作り、主導権の推定に使う
+- “主要対戦相手”の選定（最も強いボード）を実装
+
+### 9.3 テスト（最低限）
+- 3rd:
+  - Scoop3_Monster → COMPLETE/RAISE
+  - Low3_Good vs Loドアcomplete → CALL（降りすぎ防止）
+  - High3_Good vs Loドアcomplete → FOLD寄り（Scoop回避）
+- 5th/6th:
+  - HI_ONLYで相手Lo綺麗＆自分ハイ弱 → FOLD
+  - LO_ONLYでLo dead重＆相手Hi強 → FOLD
+- 7th:
+  - 片方取れそうならCALLが増える（オーバーフォールド回避）
+
+---

--- a/docs/cpu_Lv2/StudHi_CPU戦略_実装指示書.md
+++ b/docs/cpu_Lv2/StudHi_CPU戦略_実装指示書.md
@@ -1,0 +1,354 @@
+# Stud Hi CPU戦略 Lv2 実装指示書（ルールベース / 強め）
+Version: 1.0  
+Target: 7 Card Stud High（Stud Hi）  
+目的: ルールベースで「強い」CPU（Lv2）を実装する。  
+制約: CPUは `allowedActions` の範囲でアクション種別を返す。金額計算はエンジン側。  
+
+---
+
+## 0. 前提（入力・見える情報）
+
+### 0.1 入力（既存CPUインターフェース想定）
+- `state`: DealState（ディール状態）
+- `seat`: 自分のSeatIndex
+- `allowedActions`: EventType[]（このターンで実行可能なアクション）
+
+### 0.2 見えるカード情報
+- 自分: down + up 全部見える（3rdはdown2+up1、4th以降はupが増える）
+- 相手: up のみ見える
+- デッドカード（dead）は **相手・自分以外の up 全部**（fold済みも含む）を対象にする  
+  - down は見えないので dead に含めない  
+  - これにより「Live判定」がルールベースで安定する
+
+---
+
+## 1. 実装の全体構造（推奨）
+
+### 1.1 推奨モジュール構成
+- `studHiLv15.ts`
+  - `decideStudHiLv15(ctx): ActionType`
+- `studHiEval.ts`
+  - `buildVisibleContext(state, seat): VisibleContext`
+  - `eval3rdTier(my, opp, dead): Tier`
+  - `evalCategory5thPlus(my, opp, dead): Category`  // Made/Draw/Nothing
+  - `scoreThreat(oppUpCards): number`
+  - `scoreLive(drawIntent, dead): LiveScore`
+
+### 1.2 決定フロー（全ストリート共通）
+1) VisibleContext生成  
+2) street分岐（3rd / 4th / 5th / 6th / 7th）  
+3) 望ましいアクション（primary）を決める  
+4) `allowedActions` に無ければフォールバック（secondary → tertiary）  
+5) 返却
+
+---
+
+## 2. 共通定義（評価軸）
+
+### 2.1 用語
+- **Aggressor（主導権）**: 直近で攻撃行動（BRING_IN / COMPLETE / BET / RAISE）を取った側  
+  - 実装簡略化: 「このディールのこのストリートで最後に攻撃行動をした seat」を state から推定できるなら使う  
+  - 推定できない場合は「このストリート開始時に自分が最後に攻撃したか」を保持（CPU側で簡易記憶してもよい）
+
+- **Threat（相手ボード圧）**: 相手upが強く見える度合い
+- **Live（アウツの生存度）**: 自分の狙い（フラ/ストレ/ペア改善）に必要なカードが相手upにどれだけ見えているか
+
+### 2.2 返却アクション（想定）
+- "BRING_IN" / "COMPLETE" / "BET" / "RAISE" / "CALL" / "CHECK" / "FOLD"
+
+---
+
+## 3. 3rdストリート：Tier判定（参加・オープン・防衛）
+
+### 3.1 3rdの基本方針
+- 「参加するなら原則COMPLETE（= 2bet）」
+- セットマイン目的の薄いコールは禁止（弱い隠れペアを“コールだけ”で追わない）
+- スチールは行うが、無差別にはしない（ブレーキ条件あり）
+
+### 3.2 Tier定義（S/A/B/C/D）
+3rd（down2 + up1）を基準にTierを決め、状況（dead・相手up）で微調整する。
+
+#### Tier S（最強：3betも辞さない）
+- Trips（最初から3枚同ランク）
+- 隠れハイペア（down-down が JJ+）
+- 見えているハイペア（upを含む JJ+ のペア）
+
+#### Tier A（強い：基本COMPLETE、相手次第で3bet）
+- 99/TT/JJ（S未満の上位ペアは基本A以上扱いで良い）
+- 隠れミドルペア（77–TT）
+- 3フラ（A/K/Q 高スート絡み）かつ Live良
+- 3ストレ（連結度が高い、ギャップ<=1）かつ Live良（かつ高め）
+
+#### Tier B（条件付き参加：Liveと相手次第）
+- 隠れローペア（22–66）
+- 3フラ/3ストレだが、ランク低め or deadやや多め
+- A絡みでも、スート/連結などの裏付けが薄いものはB止まり
+
+#### Tier C（スチール条件なら攻撃、そうでなければ原則FOLD）
+- 高いドア単体（K/Q/J）で、ダウンが弱い
+- 連結・スートの補助がほぼ無い
+
+#### Tier D（原則FOLD）
+- 低いドア単体＋補助なし
+- deadが重い3フラ/3ストレ
+- 7-high以下のドアで特記事項なし
+
+---
+
+## 4. 3rd：パターン表（Tier判定の具体例）
+
+### 4.1 ペア系（最重要）
+- (xx)/x で down-down がペア → 隠れペア
+- (x x)/x で upがペア構成に関与 → 見えているペア（相手に強く見える）
+
+| パターン | 例 | Tier |
+|---|---|---|
+| Trips | (7 7)/7 | S |
+| 隠れハイペア | (K K)/4 | S |
+| 見えているハイペア | (K 4)/K | S |
+| 隠れミドルペア | (9 9)/2 | A |
+| 見えているミドルペア | (9 2)/9 | A（相手ドア次第でS寄り） |
+| 隠れローペア | (4 4)/Q | B（deadが悪いとC/D） |
+
+**3rdでの“強め補正”**
+- 自分upがペア要素を含む（見えているペア）の場合、同ランクでも隠れペアより1段階強く扱う（A寄り）
+
+### 4.2 3フラ（Flush draw）
+- 自分の3枚のうち同スートが3枚
+
+| パターン | 例 | Tier条件 |
+|---|---|---|
+| A-high 3フラ | (A♠ 6♠)/T♠ | A（Live良なら） |
+| K/Q-high 3フラ | (K♥ 9♥)/2♥ | A/B（Live次第） |
+| 低位3フラ | (7♦ 3♦)/2♦ | B（基本） |
+
+**Live悪化（dead）で降格**
+- 必要スートが相手upに3枚以上見えている → 2段階降格（例:A→C）
+
+### 4.3 3ストレ（Straight draw）
+- 3枚で連結度が高い（ギャップ<=1を推奨）
+
+| パターン | 例 | Tier条件 |
+|---|---|---|
+| 高位連結 | (J 9)/T | A（Live良なら） |
+| 1-gap | (Q T)/J | A/B（Live次第） |
+| 低位連結 | (6 4)/5 | B（基本） |
+
+**Live悪化（dead）で降格**
+- 必要ランクが相手upに2枚以上見えている → 1〜2段階降格
+
+---
+
+## 5. Threat（相手ボード圧）スコアリング
+
+### 5.1 Threatスコア（0〜10推奨）
+以下を相手ごとに計算し、最大値（最も危険な相手）を採用して良い。
+
+#### スコア加点ルール（相手upのみ）
+- オープンペア（同ランクupが2枚）: +5
+- 3フラ（同スートupが3枚）: +4
+- 4フラ: +6（以降ストリートで更新）
+- 3枚連結（例:T-J-Q）: +4
+- 4枚連結: +6
+- Aがupに含まれる: +2（ただし単体Aは+1でも可）
+- K/Qが複数: +1〜2（任意）
+
+**Threatの閾値（推奨）**
+- Threat >= 7: “相手が完成寄り”として扱う（ドロー・ワンペアは慎重）
+- Threat 4〜6: 中圧
+- Threat <= 3: 低圧（セミブラフが通りやすい）
+
+---
+
+## 6. Live（アウツ生存）判定（簡易）
+
+### 6.1 目的
+厳密な確率計算は不要。  
+ルールベースで「枯れている / まだ生きている」を判断する。
+
+### 6.2 deadCountの数え方
+- 相手全員のupカード（fold済み含む）から、目的に応じたカードの枚数を数える
+
+### 6.3 Live判定（3段階）
+- `LIVE_GOOD`
+- `LIVE_OK`
+- `LIVE_BAD`
+
+#### Flush（フラ狙い）のLive
+- deadSuit = 相手upに見えている同スート枚数
+  - deadSuit <= 1 → GOOD
+  - deadSuit == 2 → OK
+  - deadSuit >= 3 → BAD
+
+#### Straight（ストレ狙い）のLive
+- 自分の3〜4枚の連結から「必要ランク（end or gut）」を定義
+- deadRank = 必要ランクが相手upに見えている枚数（ランクごとに数える）
+  - maxDeadNeededRank == 0 → GOOD
+  - maxDeadNeededRank == 1 → OK
+  - maxDeadNeededRank >= 2 → BAD
+
+#### Pair improvement（ペア→Trips等）
+- 自分のペアランクが相手upに見えている枚数
+  - 0 → GOOD
+  - 1 → OK
+  - 2 → BAD（残り1枚で非常に厳しい）
+
+---
+
+## 7. ストリート別の意思決定ルール（最終版）
+
+以降、CPUは「望ましい行動」を決め、`allowedActions`に無ければフォールバックする。
+
+### 7.1 3rd（オープン：BRING_IN/COMPLETE/CALL/FOLD/RAISE）
+#### 3rd-1: 自分がBring-in担当（BRING_IN or COMPLETE）
+- Tier S/A/B → COMPLETE
+- Tier C/D → BRING_IN（最小で参加し、反応で降りる余地）
+
+#### 3rd-2: まだcompleteされていない局面（自分が先に強制でない）
+- Tier S/A → COMPLETE
+- Tier B → (Live GOOD/OK)なら COMPLETE、Live BADなら CALL or FOLD（基本FOLD寄り）
+- Tier C → スチール条件なら COMPLETE、なければ FOLD
+- Tier D → FOLD
+
+#### 3rd-3: スチール条件（COMPLETE）
+- 自分のドアが「未行動の全員」より高い  
+  かつ以下のブレーキ条件を満たさない：
+  - 自分ドアが J 以下 → スチール禁止
+  - 後ろに Aドアが残っている → スチール禁止
+  - 自分が狙うスートが既に相手upに複数見えている（>=2）→ スチール抑制（任意）
+
+#### 3rd-4: 相手COMPLETEに直面（CALL/RAISE/FOLD）
+- Tier S → RAISE（3bet）
+- Tier A → 相手ドアが自分より弱い & Threat低いなら RAISE、そうでなければ CALL
+- Tier B → Live GOOD/OKなら CALL、Live BADなら FOLD
+- Tier C/D → FOLD
+
+#### 3rd-5: 相手から3betが返ってきた後（CALL/FOLD）
+- Tier S → CALL
+- Tier A以下 → 基本FOLD（強めの損切り）
+
+---
+
+### 7.2 4th（CHECK/BET/CALL/RAISE/FOLD）
+#### 4th-1: 自分がベット可能（CHECK/BET）
+- Made（オープンペア以上）→ BET
+- Drawが強い（4フラ/強4ストレ）かつ Threat低〜中 → BET（セミブラフ）
+- それ以外は CHECK寄り（特にThreat高ならCHECK）
+
+#### 4th-2: 相手BETに直面（CALL/RAISE/FOLD）
+- 原則CALL（「基本降りない」）
+- ただしFOLD許可条件（明確理由がある時のみ）：
+  - 自分が Nothing（HighCard相当）かつ Draw薄い（Live BAD）  
+  - かつ Threat >= 7
+- RAISE条件（強め要素）：
+  - 自分がオープンペア以上になった
+  - または強いDraw（4フラ/強4ストレ）で Threat低〜中
+
+---
+
+### 7.3 5th（最重要分岐 / Big Bet）
+5th以降は `Category` を使う：
+- `M` (Made): OnePair以上（特にオープンペア加点）
+- `D` (Draw): 4フラ / 4ストレ / ペア改善が現実的
+- `N` (Nothing): 上記以外
+
+#### 5th-1: 自分がベット可能
+- M → BET（スロープレイしない）
+- D → Threat低〜中のみ BET（セミブラフ）。Threat高ならCHECK寄り
+- N → CHECK（可能なら） / 受けに回る
+
+#### 5th-2: 相手BETに直面（CALL/RAISE/FOLD）
+- M → 基本CALL。優位（自分の見えが強い、相手Threat低）ならRAISE
+- D → Live GOOD/OKならCALL、Live BADならFOLD
+- N → FOLD（ここで切れるのが強いCPU）
+
+---
+
+### 7.4 6th（Big Bet / “完成”を尊重）
+#### 6th-1: 相手の完成シグナル
+- 相手upがオープンペア維持 + 高カード追加
+- 相手が4フラ/4ストレに到達
+- 相手が5th/6thで継続的に攻撃
+
+#### 6th-2: 相手BETに直面
+- TwoPair+ → CALL/RAISE（優位ならRAISE）
+- OnePair → Threat高ならFOLDも許可（特に自分が弱いペア・Live悪い）
+- Draw → Live GOODでも、相手完成シグナル強いならFOLD（完成にぶつかるドローを切る）
+
+---
+
+### 7.5 7th（バリュー・薄いブラフキャッチ）
+#### 7th-1: 相手がチェックしてきた（自分がBET可能）
+- TwoPair+ → BET（バリュー）
+- OnePair → 相手upが弱い & 失敗ドロー多そうなら BET（薄いバリュー）
+- それ以外 → CHECK
+
+#### 7th-2: 相手BETに直面（CALL/FOLD）
+ブラフキャッチは限定的に許可。以下「条件2つ以上」でCALL推奨：
+- 相手upが完成形に見えない（ペア無し、3フラ止まり、3ストレ止まり）
+- これまで相手が攻撃継続だが、ボードが伸びていない（空砲ライン）
+- 自分が上位OnePair（A/Kペアなど）
+
+満たさない → FOLD
+
+---
+
+## 8. フォールバック規則（allowedActions対応）
+
+### 8.1 優先順位（推奨）
+- 望ましい行動が不可能なら、次善へ落とす
+
+例：
+- `RAISE`したいが無い → `CALL`（または `BET`/`CHECK` の局面なら `BET`）
+- `BET`したいが無い → `CHECK`
+- `CALL`したいが無い → `CHECK`（可能なら） / それも無いなら `FOLD`
+
+### 8.2 例外
+- BRING_IN局面は `BRING_IN` か `COMPLETE` のどちらかしか無い想定  
+  → Tierルールで必ず決められる
+
+---
+
+## 9. テスト観点（最低限）
+実装AIは以下の観点でユニットテスト（またはスナップショット）を用意すること。
+
+### 9.1 Tier判定（3rd）
+- Trips / 隠れハイペア / 見えているハイペア → S
+- 隠れミドルペア → A
+- ローペア → B
+- 高いドア単体 → C
+- 低いドア単体 → D
+- 3フラでdeadSuit>=3 → 2段階降格されること
+
+### 9.2 Threat
+- オープンペアup → +5
+- 4フラup → +6
+- 4連結up → +6
+- A含む → +2
+
+### 9.3 5th分岐
+- Category N で相手BET → FOLDになること
+- Category D で Live BAD → FOLDになること
+- Category M で Threat低 → CALL/RAISEが選ばれること
+
+---
+
+## 10. 実装上の注意（重要）
+- ルールは「強め」だが、無理な戦争（3rdでの4bet/5bet戦争）は行わない  
+- 5th以降のN（Nothing）フォールドが、強さの核  
+- ブラフキャッチは限定的（条件式で管理）  
+- 乱数は不要（同点時のみ微小ランダムは任意）
+
+---
+
+## 付録A: 3rdの“相手ドア比較”補正（任意だが強くなる）
+- 自分のupランクが相手のupより明確に高い（>=2段階）なら、Tierを1段階引き上げてもよい（ただしD→Cまで）
+- 相手にAドアが複数いる場合、自分のスチール条件は強く抑制する
+
+---
+
+## 付録B: HU補正（2人時）
+- 3rdでTier Bを「参加寄り」（A相当の扱い）にする
+- 7thブラフキャッチの条件を「2つ以上」→「1つ以上」に緩める（任意）
+
+

--- a/docs/cpu_Lv2/VisibleContext_仕様書.md
+++ b/docs/cpu_Lv2/VisibleContext_仕様書.md
@@ -1,0 +1,372 @@
+# Stud Hi CPU Lv2：VisibleContext 仕様書 & 実装テンプレ（DealState.hands版）
+
+## 0. 目的
+DealState / PlayerHand の実データ構造に基づき、CPU判断用の中間表現 `VisibleContext` を定義し、
+3rd Tier判定 / 4th〜7th Category判定 / Threat / Live を安定して実装できる状態にする。
+
+---
+
+## 1. データ構造の確定（今回の型から）
+- 自分/相手のカードは `state.hands[seat]` にある。
+  - `downCards: Card[]`（裏）
+  - `upCards: Card[]`（表）
+- プレイヤーの生存/参加は `state.players[].active` で判定できる。
+- seatの集合は `state.players[].seat` から取得する（0..playerCount-1固定と仮定しない）。
+- 現在の手番は `state.currentActorIndex`。
+- ゲーム種別は `state.gameType`（ここでは "studHi" のときのみ適用）
+
+---
+
+## 2. VisibleContext（中間表現）仕様
+
+### 2.1 型定義（推奨）
+```ts
+export type LiveGrade = "GOOD" | "OK" | "BAD";
+export type Tier3rd = "S" | "A" | "B" | "C" | "D";
+export type Category = "M" | "D" | "N"; // Made / Draw / Nothing
+
+export interface VisiblePlayer {
+  seat: number;
+  active: boolean;
+  up: Card[];
+  downCount: number;     // downを直接見せたくない場合にカウントだけ持つ
+  // NOTE: 自分だけ down を別で保持して良い（後述）
+}
+
+export interface VisibleContext {
+  street: Street;
+  me: {
+    seat: number;
+    up: Card[];
+    down: Card[];        // 自分は見えるので保持
+  };
+  opponents: VisiblePlayer[];   // 相手は up のみ参照
+  aliveSeats: number[];         // active=true の seat
+  headsUp: boolean;
+
+  // dead cards（公開情報で確定して見えているカード）
+  deadUpCards: Card[];          // 相手全員 + 自分以外のup（fold済みも含む）
+  deadRankCount: Record<Rank, number>;
+  deadSuitCount: Record<Suit, number>;
+
+  // 盤面の補助情報（任意だが便利）
+  bringInSeat: number;
+}
+```
+
+### 2.2 deadUpCards の定義（重要）
+deadUpCards = 「自分以外の全プレイヤーの upCards を全部」  
+- active=false（fold済み）でも upCards は見えている前提なので dead に含める
+- 自分のupは dead に含めない（自分の手札として扱う）
+
+---
+
+## 3. VisibleContext の生成（実装テンプレ）
+
+### 3.1 ヘルパー（rank/suitのカウント）
+```ts
+import type { Card, DealState, Rank, SeatIndex, Suit, Street } from "../types"; // パスは実装側で調整
+
+const SUITS: Suit[] = ["c", "d", "h", "s"];
+const RANKS: Rank[] = ["A","K","Q","J","T","9","8","7","6","5","4","3","2"];
+
+export const makeRankCount = (cards: Card[]): Record<Rank, number> => {
+  const init = Object.fromEntries(RANKS.map(r => [r, 0])) as Record<Rank, number>;
+  for (const c of cards) init[c.rank] += 1;
+  return init;
+};
+
+export const makeSuitCount = (cards: Card[]): Record<Suit, number> => {
+  const init = Object.fromEntries(SUITS.map(s => [s, 0])) as Record<Suit, number>;
+  for (const c of cards) init[c.suit] += 1;
+  return init;
+};
+```
+
+### 3.2 buildVisibleContext（確定版）
+```ts
+export interface VisiblePlayer {
+  seat: number;
+  active: boolean;
+  up: Card[];
+  downCount: number;
+}
+
+export interface VisibleContext {
+  street: Street;
+  me: { seat: number; up: Card[]; down: Card[] };
+  opponents: VisiblePlayer[];
+  aliveSeats: number[];
+  headsUp: boolean;
+  deadUpCards: Card[];
+  deadRankCount: Record<Rank, number>;
+  deadSuitCount: Record<Suit, number>;
+  bringInSeat: number;
+}
+
+export const buildVisibleContext = (state: DealState, meSeat: SeatIndex): VisibleContext => {
+  const myHand = state.hands[meSeat] ?? { upCards: [], downCards: [] };
+  const me = { seat: meSeat, up: myHand.upCards ?? [], down: myHand.downCards ?? [] };
+
+  const players = state.players.map(p => {
+    const hand = state.hands[p.seat] ?? { upCards: [], downCards: [] };
+    return {
+      seat: p.seat,
+      active: p.active,
+      up: hand.upCards ?? [],
+      downCount: (hand.downCards ?? []).length,
+    } satisfies VisiblePlayer;
+  });
+
+  const opponents = players.filter(p => p.seat !== meSeat);
+  const aliveSeats = players.filter(p => p.active).map(p => p.seat);
+  const headsUp = aliveSeats.length === 2;
+
+  const deadUpCards = opponents.flatMap(p => p.up);
+  const deadRankCount = makeRankCount(deadUpCards);
+  const deadSuitCount = makeSuitCount(deadUpCards);
+
+  return {
+    street: state.street,
+    me,
+    opponents,
+    aliveSeats,
+    headsUp,
+    deadUpCards,
+    deadRankCount,
+    deadSuitCount,
+    bringInSeat: state.bringInIndex,
+  };
+};
+```
+
+---
+
+## 4. Lv2 評価関数（実装しやすい最小セット）
+
+### 4.1 rank強弱（High向け）
+```ts
+const RANK_VALUE: Record<Rank, number> = {
+  "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9,
+  "T": 10, "J": 11, "Q": 12, "K": 13, "A": 14,
+};
+
+export const rankValue = (r: Rank): number => RANK_VALUE[r];
+```
+
+### 4.2 3rd Tier判定（S/A/B/C/D）
+- 対象カード：自分の (down2 + up1) = `me.down + me.up`
+- まず「ペア/トリップス」を最優先で判定
+- 次に「3フラ」「3ストレ（近接）」を判定
+- 最後に「高ドア単体」をC、その他D
+
+```ts
+export type Tier3rd = "S" | "A" | "B" | "C" | "D";
+
+const countByRank = (cards: Card[]): Record<Rank, number> => {
+  const init = Object.fromEntries(Object.keys(RANK_VALUE).map(r => [r, 0])) as Record<Rank, number>;
+  for (const c of cards) init[c.rank] += 1;
+  return init;
+};
+
+const maxSameSuit = (cards: Card[]): number => {
+  const m = new Map<Suit, number>();
+  for (const c of cards) m.set(c.suit, (m.get(c.suit) ?? 0) + 1);
+  return Math.max(0, ...Array.from(m.values()));
+};
+
+const isThreeStraightish = (cards: Card[]): boolean => {
+  // 3枚のrankValueをソートし、ギャップ合計<=2 を「近接」とみなす（簡易）
+  const vals = cards.map(c => rankValue(c.rank)).sort((a,b)=>a-b);
+  // A2345 などは厳密にやるなら補正が要るが、Lv2では簡易でOK
+  const gap1 = vals[1] - vals[0];
+  const gap2 = vals[2] - vals[1];
+  return (gap1 >= 1 && gap2 >= 1 && (gap1 + gap2) <= 3); // 連結〜1gap程度
+};
+
+export const evalTier3rd = (
+  meCards3: Card[],                 // down2+up1
+  deadRankCount: Record<Rank, number>,
+  deadSuitCount: Record<Suit, number>,
+): Tier3rd => {
+  const byRank = countByRank(meCards3);
+  const ranks = Object.keys(byRank) as Rank[];
+
+  const hasTrips = ranks.some(r => byRank[r] === 3);
+  if (hasTrips) return "S";
+
+  const pairRank = ranks.find(r => byRank[r] === 2);
+  if (pairRank) {
+    const v = rankValue(pairRank);
+    if (v >= 11) return "S";      // JJ+
+    if (v >= 7) return "A";       // 77–TT
+    return "B";                   // 22–66
+  }
+
+  // 3-flush
+  const suitMax = maxSameSuit(meCards3);
+  if (suitMax === 3) {
+    // Live: deadSuit>=3 なら2段階降格
+    const suit = meCards3[0].suit; // 3枚同スート前提（厳密には検出する）
+    const deadSuit = deadSuitCount[suit] ?? 0;
+
+    // A/K/Q を含むなら上位
+    const high = Math.max(...meCards3.map(c => rankValue(c.rank)));
+    const base: Tier3rd = (high >= 12) ? "A" : "B"; // Q以上含む→A
+    if (deadSuit >= 3) return "C";
+    if (deadSuit === 2 && base === "A") return "B";
+    return base;
+  }
+
+  // 3-straight-ish
+  if (isThreeStraightish(meCards3)) {
+    // Live: 必要ランク算出は簡易化して、deadRankが多いほど降格（任意）
+    const high = Math.max(...meCards3.map(c => rankValue(c.rank)));
+    return (high >= 11) ? "A" : "B"; // J以上を含むならA
+  }
+
+  // 高ドア単体
+  // up1枚は meCards3 に含まれている前提で「最大ランク」をドア相当として扱うのは雑なので、
+  // 実装側で "meUp[0]" をドアとして渡してもよい。ここでは簡易に最大で判定。
+  const doorHigh = Math.max(...meCards3.map(c => rankValue(c.rank)));
+  if (doorHigh >= 11) return "C"; // J/Q/K/A
+  return "D";
+};
+```
+
+※ 上は“最小で動く”実装例です。  
+あなたがより強くしたい場合、**ドアカードは `me.up[0]` を明確に参照**し、ダウン2枚の情報と分離して評価するほうが精度が上がります。
+
+---
+
+## 5. Threat（相手ボード圧）の最小実装
+- 相手ごとにスコア計算し、最大値を採用
+
+```ts
+export const scoreThreatForUp = (up: Card[]): number => {
+  if (up.length === 0) return 0;
+  let score = 0;
+
+  // pair in up
+  const byRank = new Map<Rank, number>();
+  const bySuit = new Map<Suit, number>();
+  for (const c of up) {
+    byRank.set(c.rank, (byRank.get(c.rank) ?? 0) + 1);
+    bySuit.set(c.suit, (bySuit.get(c.suit) ?? 0) + 1);
+  }
+
+  const hasOpenPair = Array.from(byRank.values()).some(v => v >= 2);
+  if (hasOpenPair) score += 5;
+
+  const maxSuit = Math.max(0, ...Array.from(bySuit.values()));
+  if (maxSuit === 3) score += 4;
+  if (maxSuit >= 4) score += 6;
+
+  // A high pressure
+  if (up.some(c => c.rank === "A")) score += 2;
+  const highCount = up.filter(c => ["K","Q"].includes(c.rank)).length;
+  if (highCount >= 2) score += 1;
+
+  // straight-ish up (簡易: 値をソートし、連結3枚以上なら加点)
+  const vals = up.map(c => rankValue(c.rank)).sort((a,b)=>a-b);
+  let run = 1;
+  for (let i=1;i<vals.length;i++) {
+    if (vals[i] === vals[i-1] + 1) run += 1;
+    else run = 1;
+    if (run === 3) score += 4;
+    if (run === 4) score += 6;
+  }
+
+  return Math.min(score, 10);
+};
+
+export const scoreThreat = (opponents: { up: Card[] }[]): number => {
+  let max = 0;
+  for (const o of opponents) max = Math.max(max, scoreThreatForUp(o.up));
+  return max;
+};
+```
+
+---
+
+## 6. Live判定（フラ/ストレ/ペア改善の最小実装）
+Lv2では「GOOD/OK/BAD」の3段階で十分。
+
+```ts
+export type LiveGrade = "GOOD" | "OK" | "BAD";
+
+export const liveForFlushSuit = (
+  suit: Suit,
+  deadSuitCount: Record<Suit, number>,
+): LiveGrade => {
+  const dead = deadSuitCount[suit] ?? 0;
+  if (dead <= 1) return "GOOD";
+  if (dead === 2) return "OK";
+  return "BAD"; // >=3
+};
+
+export const liveForPairImprove = (
+  pairRank: Rank,
+  deadRankCount: Record<Rank, number>,
+): LiveGrade => {
+  const dead = deadRankCount[pairRank] ?? 0;
+  if (dead === 0) return "GOOD";
+  if (dead === 1) return "OK";
+  return "BAD"; // >=2
+};
+```
+
+ストレの必要ランクを厳密に出すのはやや面倒なので、Lv2では次のいずれかを推奨：
+- A案: “必要ランク算出”まで実装して deadRankCount 参照（精度高）
+- B案: “3ストレ/4ストレ判定だけ”にして Liveは一律OK扱い（簡易だが強さは少し落ちる）
+
+まずはA案が良いです（強めにしたいので）。
+
+---
+
+## 7. 4th〜7thのCategory（M/D/N）最小実装
+厳密な役判定ロジックは別に既存があるはずなので、CPU側では軽量に分類して良い。
+
+### 7.1 簡易分類ルール
+- M: 自分の見えているカード（up+down）で
+  - ペア以上が確定、または
+  - upにオープンペアがある
+- D: 4フラ or 4ストレ（近接）などが見えている
+- N: 上記以外
+
+（役判定関数を呼べるならそれを使ってM判定を強化してよい）
+
+---
+
+## 8. allowedActions フォールバック共通関数
+CPUは「望ましいアクション」を返したいが、許可されない場合があるので必須。
+
+```ts
+import type { EventType } from "../types";
+
+const has = (allowed: EventType[], t: EventType) => allowed.includes(t);
+
+export const pickAction = (
+  allowed: EventType[],
+  pref: EventType[],
+): EventType => {
+  for (const t of pref) if (has(allowed, t)) return t;
+  // 最低限の保険
+  if (has(allowed, "CHECK")) return "CHECK";
+  if (has(allowed, "CALL")) return "CALL";
+  if (has(allowed, "FOLD")) return "FOLD";
+  // ここまで来るのは想定外
+  return allowed[0];
+};
+```
+
+---
+
+## 9. 次に実装するファイル（実装AIへの具体タスク）
+1) `buildVisibleContext(state, seat)` を実装しテスト
+2) `evalTier3rd()` を実装しテスト
+3) `scoreThreat()` を実装しテスト
+4) `studHiLv15.decide()` で streetごとの意思決定を実装
+5) 主要ケースをスナップショット or テーブル駆動でテスト（Tier/Threat/5th分岐が特に重要）
+
+---

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -3,7 +3,7 @@ import type { DealState, GameState } from "../domain/types";
 export type Screen = "SETUP" | "PLAY" | "HISTORY" | "SETTINGS";
 
 /** CPU戦略レベル */
-export type CpuLevel = "lv0" | "lv1";
+export type CpuLevel = "lv0" | "lv1" | "lv2";
 
 export interface UiState {
   screen: Screen;

--- a/src/domain/cpu/decideLv2.ts
+++ b/src/domain/cpu/decideLv2.ts
@@ -1,0 +1,28 @@
+/**
+ * CPU Lv2 意思決定の統括
+ *
+ * ゲームタイプ別にLv2戦略を呼び分ける。
+ * Lv2未実装のゲームタイプはLv1にフォールバック。
+ */
+
+import { decideLv1 } from "./decideLv1";
+import { decideStudHiLv2 } from "./decideStudHiLv2";
+import type { ActionType, CpuDecisionContext } from "./policy";
+
+/**
+ * Lv2 CPU の意思決定ロジック
+ *
+ * @param ctx - CpuDecisionContext
+ * @returns ActionType
+ */
+export const decideLv2 = (ctx: CpuDecisionContext): ActionType => {
+  const { state } = ctx;
+
+  // Stud Hi → Lv2専用戦略
+  if (state.gameType === "studHi") {
+    return decideStudHiLv2(ctx);
+  }
+
+  // Razz / Stud8 → Lv1にフォールバック（将来Lv2実装予定）
+  return decideLv1(ctx);
+};

--- a/src/domain/cpu/decideStudHiLv2.ts
+++ b/src/domain/cpu/decideStudHiLv2.ts
@@ -1,0 +1,526 @@
+/**
+ * Stud Hi CPU Lv2: 意思決定ロジック
+ *
+ * ストリート別の意思決定ルールを実装。
+ * 仕様: docs/cpu_Lv2/StudHi_CPU戦略_実装指示書.md
+ */
+
+import type { EventType, Rank, Suit } from "../types";
+import type { ActionType, CpuDecisionContext } from "./policy";
+import {
+  evalCategory,
+  evalTier3rd,
+  liveForFlushSuit,
+  liveForPairImprove,
+  rankValue,
+  scoreThreat,
+} from "./studHi/eval";
+import {
+  buildVisibleContext,
+  type LiveGrade,
+  type VisibleContext,
+} from "./studHi/visibleContext";
+
+// ============================================================
+// フォールバック関数
+// ============================================================
+
+const has = (allowed: EventType[], t: EventType) => allowed.includes(t);
+
+/**
+ * 望ましいアクションを優先順位リストから選択
+ * allowedActionsに含まれる最初のアクションを返す
+ */
+export const pickAction = (
+  allowed: EventType[],
+  pref: ActionType[],
+): ActionType => {
+  for (const t of pref) {
+    if (has(allowed, t)) return t;
+  }
+  // 最低限の保険
+  if (has(allowed, "CHECK")) return "CHECK";
+  if (has(allowed, "CALL")) return "CALL";
+  if (has(allowed, "FOLD")) return "FOLD";
+  // ここまで来るのは想定外
+  return (allowed[0] as ActionType) ?? "FOLD";
+};
+
+// ============================================================
+// ヘルパー関数
+// ============================================================
+
+/**
+ * 自分のupカードの最大ランク値を取得
+ */
+const getMyDoorRank = (ctx: VisibleContext): number => {
+  if (ctx.me.up.length === 0) return 0;
+  return Math.max(...ctx.me.up.map((c) => rankValue(c.rank)));
+};
+
+/**
+ * 未行動の相手のドアランク最大値を取得
+ */
+const getMaxOppDoorRank = (ctx: VisibleContext): number => {
+  const activeOpps = ctx.opponents.filter((p) =>
+    ctx.aliveSeats.includes(p.seat),
+  );
+  if (activeOpps.length === 0) return 0;
+
+  let max = 0;
+  for (const opp of activeOpps) {
+    if (opp.up.length > 0) {
+      const oppDoor = Math.max(...opp.up.map((c) => rankValue(c.rank)));
+      max = Math.max(max, oppDoor);
+    }
+  }
+  return max;
+};
+
+/**
+ * 後ろにAドアがいるか判定
+ */
+const hasAceDoorBehind = (ctx: VisibleContext): boolean => {
+  const activeOpps = ctx.opponents.filter((p) =>
+    ctx.aliveSeats.includes(p.seat),
+  );
+  return activeOpps.some((opp) => opp.up.some((c) => c.rank === "A"));
+};
+
+/**
+ * スチール条件を満たすか判定
+ */
+const canSteal = (ctx: VisibleContext): boolean => {
+  const myDoor = getMyDoorRank(ctx);
+  const maxOppDoor = getMaxOppDoorRank(ctx);
+
+  // 自分のドアがJ以下 → スチール禁止
+  if (myDoor <= 11) return false;
+
+  // 後ろにAドアがいる → スチール禁止
+  if (hasAceDoorBehind(ctx)) return false;
+
+  // 自分のドアが全員より高い
+  return myDoor > maxOppDoor;
+};
+
+/**
+ * 自分の手札から最も多いスートを取得
+ */
+const getMostSuit = (cards: { suit: Suit }[]): Suit | null => {
+  const m = new Map<Suit, number>();
+  for (const c of cards) {
+    m.set(c.suit, (m.get(c.suit) ?? 0) + 1);
+  }
+  let maxSuit: Suit | null = null;
+  let maxCount = 0;
+  for (const [suit, count] of m.entries()) {
+    if (count > maxCount) {
+      maxSuit = suit;
+      maxCount = count;
+    }
+  }
+  return maxSuit;
+};
+
+/**
+ * 自分のペアランクを取得
+ */
+const getPairRank = (cards: { rank: Rank }[]): Rank | null => {
+  const m = new Map<Rank, number>();
+  for (const c of cards) {
+    m.set(c.rank, (m.get(c.rank) ?? 0) + 1);
+  }
+  for (const [rank, count] of m.entries()) {
+    if (count >= 2) return rank;
+  }
+  return null;
+};
+
+/**
+ * 自分のLive状態を取得（フラッシュorペア改善）
+ */
+const getMyLive = (ctx: VisibleContext): LiveGrade => {
+  const allCards = [...ctx.me.down, ...ctx.me.up];
+
+  // まずペアがあるか確認
+  const pairRank = getPairRank(allCards);
+  if (pairRank) {
+    return liveForPairImprove(pairRank, ctx.deadRankCount);
+  }
+
+  // 次にフラッシュドロー判定
+  const mostSuit = getMostSuit(allCards);
+  if (mostSuit) {
+    return liveForFlushSuit(mostSuit, ctx.deadSuitCount);
+  }
+
+  return "OK"; // デフォルト
+};
+
+// ============================================================
+// 3rd Street 決定ロジック
+// ============================================================
+
+const decide3rd = (
+  ctx: CpuDecisionContext,
+  vctx: VisibleContext,
+): ActionType => {
+  const allowed = ctx.allowedActions;
+  const meCards3 = [...vctx.me.down, ...vctx.me.up];
+  const tier = evalTier3rd(meCards3, vctx.deadRankCount, vctx.deadSuitCount);
+  const threat = scoreThreat(vctx.opponents);
+  const live = getMyLive(vctx);
+
+  // 3rd-1: 自分がBring-in担当
+  if (has(allowed, "BRING_IN")) {
+    // Tier S/A/B → COMPLETE
+    if (tier === "S" || tier === "A" || tier === "B") {
+      if (has(allowed, "COMPLETE")) return "COMPLETE";
+    }
+    // Tier C/D → BRING_IN
+    return "BRING_IN";
+  }
+
+  // 3rd-2: まだcompleteされていない（COMPLETEが選択可能）
+  if (has(allowed, "COMPLETE") && !has(allowed, "RAISE")) {
+    if (tier === "S" || tier === "A") {
+      return "COMPLETE";
+    }
+    if (tier === "B") {
+      if (live === "GOOD" || live === "OK") {
+        return "COMPLETE";
+      }
+      // Live BAD → FOLD寄り
+      return pickAction(allowed, ["FOLD", "CALL"]);
+    }
+    if (tier === "C") {
+      // スチール条件なら COMPLETE
+      if (canSteal(vctx)) {
+        return "COMPLETE";
+      }
+      return pickAction(allowed, ["FOLD", "CALL"]);
+    }
+    // Tier D
+    return pickAction(allowed, ["FOLD", "CALL"]);
+  }
+
+  // 3rd-4: 相手COMPLETEに直面（CALL/RAISE/FOLD）
+  if (has(allowed, "RAISE") || has(allowed, "CALL")) {
+    if (tier === "S") {
+      return pickAction(allowed, ["RAISE", "CALL"]);
+    }
+    if (tier === "A") {
+      // 相手ドアが自分より弱い & Threat低いなら RAISE
+      const myDoor = getMyDoorRank(vctx);
+      const maxOppDoor = getMaxOppDoorRank(vctx);
+      if (myDoor > maxOppDoor && threat <= 3) {
+        return pickAction(allowed, ["RAISE", "CALL"]);
+      }
+      return pickAction(allowed, ["CALL"]);
+    }
+    if (tier === "B") {
+      if (live === "GOOD" || live === "OK") {
+        return pickAction(allowed, ["CALL"]);
+      }
+      return pickAction(allowed, ["FOLD"]);
+    }
+    // Tier C/D
+    return pickAction(allowed, ["FOLD"]);
+  }
+
+  // フォールバック
+  return pickAction(allowed, ["CHECK", "CALL", "FOLD"]);
+};
+
+// ============================================================
+// 4th Street 決定ロジック
+// ============================================================
+
+const decide4th = (
+  ctx: CpuDecisionContext,
+  vctx: VisibleContext,
+): ActionType => {
+  const allowed = ctx.allowedActions;
+  const meCards = [...vctx.me.down, ...vctx.me.up];
+  const category = evalCategory(
+    meCards,
+    vctx.deadRankCount,
+    vctx.deadSuitCount,
+  );
+  const threat = scoreThreat(vctx.opponents);
+  const live = getMyLive(vctx);
+  const currentBet = ctx.state.currentBet;
+
+  // currentBet == 0: 自分がベット可能（CHECK/BET）
+  if (currentBet === 0) {
+    // Made → BET
+    if (category === "M") {
+      return pickAction(allowed, ["BET", "CHECK"]);
+    }
+    // Draw + 低〜中Threat → セミブラフBET
+    if (category === "D" && threat <= 6) {
+      return pickAction(allowed, ["BET", "CHECK"]);
+    }
+    // Nothing or 高Threat → CHECK
+    return pickAction(allowed, ["CHECK"]);
+  }
+
+  // currentBet > 0: 相手BETに直面（CALL/RAISE/FOLD）
+  // 原則CALL（「基本降りない」）
+
+  // FOLD許可条件: Nothing + Draw薄い + Threat高い
+  if (category === "N" && live === "BAD" && threat >= 7) {
+    return pickAction(allowed, ["FOLD", "CALL"]);
+  }
+
+  // RAISE条件: Made（オープンペア以上） or 強いDraw + 低〜中Threat
+  if (category === "M" || (category === "D" && threat <= 6)) {
+    // 強い場合はRAISEも考慮
+    if (category === "M" && threat <= 4) {
+      return pickAction(allowed, ["RAISE", "CALL"]);
+    }
+    return pickAction(allowed, ["CALL"]);
+  }
+
+  // 基本CALL
+  return pickAction(allowed, ["CALL", "FOLD"]);
+};
+
+// ============================================================
+// 5th Street 決定ロジック（最重要分岐 / Big Bet）
+// ============================================================
+
+const decide5th = (
+  ctx: CpuDecisionContext,
+  vctx: VisibleContext,
+): ActionType => {
+  const allowed = ctx.allowedActions;
+  const meCards = [...vctx.me.down, ...vctx.me.up];
+  const category = evalCategory(
+    meCards,
+    vctx.deadRankCount,
+    vctx.deadSuitCount,
+  );
+  const threat = scoreThreat(vctx.opponents);
+  const live = getMyLive(vctx);
+  const currentBet = ctx.state.currentBet;
+
+  // 5th-1: 自分がベット可能
+  if (currentBet === 0) {
+    // M → BET（スロープレイしない）
+    if (category === "M") {
+      return pickAction(allowed, ["BET", "CHECK"]);
+    }
+    // D → Threat低〜中のみ BET（セミブラフ）
+    if (category === "D" && threat <= 6) {
+      return pickAction(allowed, ["BET", "CHECK"]);
+    }
+    // N → CHECK
+    return pickAction(allowed, ["CHECK"]);
+  }
+
+  // 5th-2: 相手BETに直面（CALL/RAISE/FOLD）
+  // M → 基本CALL。優位ならRAISE
+  if (category === "M") {
+    if (threat <= 4) {
+      return pickAction(allowed, ["RAISE", "CALL"]);
+    }
+    return pickAction(allowed, ["CALL"]);
+  }
+
+  // D → Live GOOD/OKならCALL、Live BADならFOLD
+  if (category === "D") {
+    if (live === "GOOD" || live === "OK") {
+      return pickAction(allowed, ["CALL"]);
+    }
+    return pickAction(allowed, ["FOLD", "CALL"]);
+  }
+
+  // N → FOLD（ここで切れるのが強いCPU）
+  return pickAction(allowed, ["FOLD", "CALL"]);
+};
+
+// ============================================================
+// 6th Street 決定ロジック（Big Bet / "完成"を尊重）
+// ============================================================
+
+const decide6th = (
+  ctx: CpuDecisionContext,
+  vctx: VisibleContext,
+): ActionType => {
+  const allowed = ctx.allowedActions;
+  const meCards = [...vctx.me.down, ...vctx.me.up];
+  const category = evalCategory(
+    meCards,
+    vctx.deadRankCount,
+    vctx.deadSuitCount,
+  );
+  const threat = scoreThreat(vctx.opponents);
+  const live = getMyLive(vctx);
+  const currentBet = ctx.state.currentBet;
+
+  // currentBet == 0
+  if (currentBet === 0) {
+    if (category === "M") {
+      return pickAction(allowed, ["BET", "CHECK"]);
+    }
+    return pickAction(allowed, ["CHECK"]);
+  }
+
+  // 相手BETに直面
+  // TwoPair+ → CALL/RAISE
+  // 簡易判定: Mでペアが2つ以上あるかチェック
+  const hasTwoPairPlus = (() => {
+    const m = new Map<Rank, number>();
+    for (const c of meCards) {
+      m.set(c.rank, (m.get(c.rank) ?? 0) + 1);
+    }
+    const pairs = Array.from(m.values()).filter((v) => v >= 2).length;
+    return pairs >= 2;
+  })();
+
+  if (hasTwoPairPlus) {
+    if (threat <= 5) {
+      return pickAction(allowed, ["RAISE", "CALL"]);
+    }
+    return pickAction(allowed, ["CALL"]);
+  }
+
+  // OnePair → Threat高ならFOLDも許可
+  if (category === "M") {
+    if (threat >= 7 && live === "BAD") {
+      return pickAction(allowed, ["FOLD", "CALL"]);
+    }
+    return pickAction(allowed, ["CALL"]);
+  }
+
+  // Draw → Live GOODでも、相手完成シグナル強いならFOLD
+  if (category === "D") {
+    if (threat >= 7) {
+      return pickAction(allowed, ["FOLD", "CALL"]);
+    }
+    if (live === "GOOD" || live === "OK") {
+      return pickAction(allowed, ["CALL"]);
+    }
+    return pickAction(allowed, ["FOLD", "CALL"]);
+  }
+
+  // N → FOLD
+  return pickAction(allowed, ["FOLD", "CALL"]);
+};
+
+// ============================================================
+// 7th Street 決定ロジック（バリュー・薄いブラフキャッチ）
+// ============================================================
+
+const decide7th = (
+  ctx: CpuDecisionContext,
+  vctx: VisibleContext,
+): ActionType => {
+  const allowed = ctx.allowedActions;
+  const meCards = [...vctx.me.down, ...vctx.me.up];
+  const category = evalCategory(
+    meCards,
+    vctx.deadRankCount,
+    vctx.deadSuitCount,
+  );
+  const threat = scoreThreat(vctx.opponents);
+  const currentBet = ctx.state.currentBet;
+
+  // 7th-1: 相手がチェックしてきた（自分がBET可能）
+  if (currentBet === 0) {
+    // TwoPair+ → BET（バリュー）
+    const hasTwoPairPlus = (() => {
+      const m = new Map<Rank, number>();
+      for (const c of meCards) {
+        m.set(c.rank, (m.get(c.rank) ?? 0) + 1);
+      }
+      const pairs = Array.from(m.values()).filter((v) => v >= 2).length;
+      return pairs >= 2;
+    })();
+
+    if (hasTwoPairPlus) {
+      return pickAction(allowed, ["BET", "CHECK"]);
+    }
+
+    // OnePair → 相手upが弱ければ薄いバリューBET
+    if (category === "M" && threat <= 3) {
+      return pickAction(allowed, ["BET", "CHECK"]);
+    }
+
+    // それ以外 → CHECK
+    return pickAction(allowed, ["CHECK"]);
+  }
+
+  // 7th-2: 相手BETに直面（CALL/FOLD）
+  // ブラフキャッチは限定的に許可
+  // 条件: 相手upが完成形に見えない, 自分が上位OnePair
+
+  // 簡易判定: 高ランクペアを持っているか
+  const hasHighPair = (() => {
+    const m = new Map<Rank, number>();
+    for (const c of meCards) {
+      m.set(c.rank, (m.get(c.rank) ?? 0) + 1);
+    }
+    for (const [rank, count] of m.entries()) {
+      if (count >= 2 && rankValue(rank) >= 12) {
+        // Q以上のペア
+        return true;
+      }
+    }
+    return false;
+  })();
+
+  // 条件2つ以上でCALL
+  let callConditions = 0;
+  if (threat <= 4) callConditions++; // 相手upが完成形に見えない
+  if (hasHighPair) callConditions++; // 上位OnePair
+
+  if (callConditions >= 2 || category === "M") {
+    return pickAction(allowed, ["CALL"]);
+  }
+
+  // 満たさない → FOLD
+  return pickAction(allowed, ["FOLD", "CALL"]);
+};
+
+// ============================================================
+// メイン決定関数
+// ============================================================
+
+/**
+ * Stud Hi CPU Lv2 意思決定
+ */
+export const decideStudHiLv2 = (ctx: CpuDecisionContext): ActionType => {
+  const allowed = ctx.allowedActions;
+
+  // 選択肢が1つならそれを返す
+  if (allowed.length === 1) {
+    return allowed[0] as ActionType;
+  }
+
+  // 選択肢がない場合のフォールバック
+  if (allowed.length === 0) {
+    return "FOLD";
+  }
+
+  // VisibleContextを生成
+  const vctx = buildVisibleContext(ctx.state, ctx.seat);
+
+  // ストリート別に分岐
+  switch (vctx.street) {
+    case "3rd":
+      return decide3rd(ctx, vctx);
+    case "4th":
+      return decide4th(ctx, vctx);
+    case "5th":
+      return decide5th(ctx, vctx);
+    case "6th":
+      return decide6th(ctx, vctx);
+    case "7th":
+      return decide7th(ctx, vctx);
+    default:
+      return pickAction(allowed, ["CHECK", "CALL", "FOLD"]);
+  }
+};

--- a/src/domain/cpu/policy.ts
+++ b/src/domain/cpu/policy.ts
@@ -1,5 +1,6 @@
 import type { DealState, EventType, SeatIndex } from "../types";
 import { decideLv1 } from "./decideLv1";
+import { decideLv2 } from "./decideLv2";
 
 /**
  * CPUが選択可能なアクションタイプ（STREET_ADVANCE/DEAL_ENDは含まない）
@@ -51,5 +52,15 @@ export const cpuLv0: CpuStrategy = {
 export const cpuLv1: CpuStrategy = {
   decide(ctx) {
     return decideLv1(ctx);
+  },
+};
+
+/**
+ * Lv2 CPU戦略
+ * ルールベースでより強い意思決定を行う
+ */
+export const cpuLv2: CpuStrategy = {
+  decide(ctx) {
+    return decideLv2(ctx);
   },
 };

--- a/src/domain/cpu/runner.ts
+++ b/src/domain/cpu/runner.ts
@@ -2,10 +2,10 @@ import { applyEvent } from "../engine/applyEvent";
 import { getAllowedActions } from "../rules/allowedActions";
 import type { DealState, Event } from "../types";
 import { createEventFromAction } from "./eventFactory";
-import { type ActionType, cpuLv0, cpuLv1 } from "./policy";
+import { type ActionType, cpuLv0, cpuLv1, cpuLv2 } from "./policy";
 
 /** CPU戦略レベル */
-export type CpuLevel = "lv0" | "lv1";
+export type CpuLevel = "lv0" | "lv1" | "lv2";
 
 /**
  * CPUターンを実行する（1アクション分）
@@ -44,7 +44,11 @@ export const runCpuTurn = (
   }
 
   // CPU戦略を選択
-  const strategy = cpuLevel === "lv0" ? cpuLv0 : cpuLv1;
+  const strategy = (() => {
+    if (cpuLevel === "lv0") return cpuLv0;
+    if (cpuLevel === "lv2") return cpuLv2;
+    return cpuLv1;
+  })();
 
   // CPU戦略でアクションを決定
   const action = strategy.decide({

--- a/src/domain/cpu/studHi/eval.ts
+++ b/src/domain/cpu/studHi/eval.ts
@@ -1,0 +1,327 @@
+/**
+ * Stud Hi CPU Lv2: 評価関数群
+ *
+ * 3rd Tier判定、Threat、Live、Category判定を実装。
+ * 仕様: docs/cpu_Lv2/StudHi_CPU戦略_実装指示書.md
+ */
+
+import type { Card, Rank, Suit } from "../../types";
+import type {
+  Category,
+  LiveGrade,
+  Tier3rd,
+  VisiblePlayer,
+} from "./visibleContext";
+
+// ============================================================
+// 定数
+// ============================================================
+
+/** ランクを数値に変換（High用: A=14） */
+const RANK_VALUE: Record<Rank, number> = {
+  "2": 2,
+  "3": 3,
+  "4": 4,
+  "5": 5,
+  "6": 6,
+  "7": 7,
+  "8": 8,
+  "9": 9,
+  T: 10,
+  J: 11,
+  Q: 12,
+  K: 13,
+  A: 14,
+};
+
+/** ランクを数値化 */
+export const rankValue = (r: Rank): number => RANK_VALUE[r];
+
+// ============================================================
+// ヘルパー関数
+// ============================================================
+
+/**
+ * カード配列からランクごとの枚数をカウント（ローカル用）
+ */
+const countByRank = (cards: Card[]): Record<Rank, number> => {
+  const init = Object.fromEntries(
+    Object.keys(RANK_VALUE).map((r) => [r, 0]),
+  ) as Record<Rank, number>;
+  for (const c of cards) {
+    init[c.rank] += 1;
+  }
+  return init;
+};
+
+/**
+ * 同じスートの最大枚数を取得
+ */
+const maxSameSuit = (cards: Card[]): number => {
+  const m = new Map<Suit, number>();
+  for (const c of cards) {
+    m.set(c.suit, (m.get(c.suit) ?? 0) + 1);
+  }
+  return Math.max(0, ...Array.from(m.values()));
+};
+
+/**
+ * 3枚で連結度が高いか判定（ギャップ合計<=3を"近接"とみなす）
+ */
+const isThreeStraightish = (cards: Card[]): boolean => {
+  if (cards.length !== 3) return false;
+  const vals = cards.map((c) => rankValue(c.rank)).sort((a, b) => a - b);
+  const gap1 = vals[1] - vals[0];
+  const gap2 = vals[2] - vals[1];
+  // 連結〜1gap程度: 各ギャップが1以上で、合計が3以下
+  return gap1 >= 1 && gap2 >= 1 && gap1 + gap2 <= 3;
+};
+
+/**
+ * 4枚で4ストレート（連結度が高い）か判定
+ */
+const isFourStraightish = (cards: Card[]): boolean => {
+  if (cards.length < 4) return false;
+
+  const ranks = cards.map((c) => rankValue(c.rank));
+  const unique = [...new Set(ranks)].sort((a, b) => a - b);
+
+  // A-2-3-4 の場合も考慮（A=14 だが A-low として 1 も扱う）
+  const withAceLow = unique.includes(14) ? [...unique, 1] : unique;
+  const sortedWithAce = [...new Set(withAceLow)].sort((a, b) => a - b);
+
+  // 4枚連続 or 1-gap を探す
+  for (let i = 0; i <= sortedWithAce.length - 4; i++) {
+    let gapCount = 0;
+    for (let j = 0; j < 3; j++) {
+      const diff = sortedWithAce[i + j + 1] - sortedWithAce[i + j];
+      if (diff === 1) continue;
+      if (diff === 2) gapCount++;
+      else {
+        gapCount = 99;
+        break;
+      }
+    }
+    if (gapCount <= 1) return true;
+  }
+  return false;
+};
+
+/**
+ * 3枚のカードで最も多いスートを取得
+ */
+const getFlushSuit = (cards: Card[]): Suit | null => {
+  const m = new Map<Suit, number>();
+  for (const c of cards) {
+    m.set(c.suit, (m.get(c.suit) ?? 0) + 1);
+  }
+  for (const [suit, count] of m.entries()) {
+    if (count >= 3) return suit;
+  }
+  return null;
+};
+
+// ============================================================
+// 3rd Street Tier判定
+// ============================================================
+
+/**
+ * 3rd StreetのTier評価（S/A/B/C/D）
+ *
+ * @param meCards3 - 自分のカード（down2 + up1 = 3枚）
+ * @param deadRankCount - デッドカードのランク別カウント
+ * @param deadSuitCount - デッドカードのスート別カウント
+ * @returns Tier3rd
+ */
+export const evalTier3rd = (
+  meCards3: Card[],
+  _deadRankCount: Record<Rank, number>,
+  deadSuitCount: Record<Suit, number>,
+): Tier3rd => {
+  if (meCards3.length !== 3) {
+    // 3枚でない場合はフォールバック
+    return "D";
+  }
+
+  const byRank = countByRank(meCards3);
+  const ranks = Object.keys(byRank) as Rank[];
+
+  // 1. Trips判定
+  const hasTrips = ranks.some((r) => byRank[r] === 3);
+  if (hasTrips) return "S";
+
+  // 2. ペア判定
+  const pairRank = ranks.find((r) => byRank[r] === 2);
+  if (pairRank) {
+    const v = rankValue(pairRank);
+    if (v >= 11) return "S"; // JJ+
+    if (v >= 7) return "A"; // 77–TT
+    return "B"; // 22–66
+  }
+
+  // 3. 3-flush判定
+  const suitMax = maxSameSuit(meCards3);
+  if (suitMax === 3) {
+    const suit = getFlushSuit(meCards3);
+    const deadSuit = suit ? (deadSuitCount[suit] ?? 0) : 0;
+
+    // A/K/Q を含むなら上位
+    const high = Math.max(...meCards3.map((c) => rankValue(c.rank)));
+    const base: Tier3rd = high >= 12 ? "A" : "B"; // Q以上含む→A
+
+    // Live判定: deadSuit >= 3 なら2段階降格
+    if (deadSuit >= 3) return "C";
+    if (deadSuit === 2 && base === "A") return "B";
+    return base;
+  }
+
+  // 4. 3-straight-ish判定
+  if (isThreeStraightish(meCards3)) {
+    const high = Math.max(...meCards3.map((c) => rankValue(c.rank)));
+    return high >= 11 ? "A" : "B"; // J以上を含むならA
+  }
+
+  // 5. 高ドア単体
+  const doorHigh = Math.max(...meCards3.map((c) => rankValue(c.rank)));
+  if (doorHigh >= 11) return "C"; // J/Q/K/A
+  return "D";
+};
+
+// ============================================================
+// 4th〜7th Category判定
+// ============================================================
+
+/**
+ * Category評価（M/D/N）
+ *
+ * @param meCards - 自分のカード（down + up 全て）
+ * @param _deadRankCount - デッドカードのランク別カウント（将来拡張用）
+ * @param _deadSuitCount - デッドカードのスート別カウント（将来拡張用）
+ * @returns Category
+ */
+export const evalCategory = (
+  meCards: Card[],
+  _deadRankCount: Record<Rank, number>,
+  _deadSuitCount: Record<Suit, number>,
+): Category => {
+  const byRank = countByRank(meCards);
+  const ranks = Object.keys(byRank) as Rank[];
+
+  // Made: ペア以上が確定
+  const hasPair = ranks.some((r) => byRank[r] >= 2);
+  if (hasPair) return "M";
+
+  // Draw: 4フラ or 4ストレ
+  const suitMax = maxSameSuit(meCards);
+  if (suitMax >= 4) return "D";
+  if (isFourStraightish(meCards)) return "D";
+
+  // Nothing
+  return "N";
+};
+
+// ============================================================
+// Threat（相手ボード圧）
+// ============================================================
+
+/**
+ * 単一相手のupCardsからThreatスコアを計算
+ */
+export const scoreThreatForUp = (up: Card[]): number => {
+  if (up.length === 0) return 0;
+  let score = 0;
+
+  // ランク・スート別カウント
+  const byRank = new Map<Rank, number>();
+  const bySuit = new Map<Suit, number>();
+  for (const c of up) {
+    byRank.set(c.rank, (byRank.get(c.rank) ?? 0) + 1);
+    bySuit.set(c.suit, (bySuit.get(c.suit) ?? 0) + 1);
+  }
+
+  // オープンペア +5
+  const hasOpenPair = Array.from(byRank.values()).some((v) => v >= 2);
+  if (hasOpenPair) score += 5;
+
+  // フラッシュ判定
+  const maxSuit = Math.max(0, ...Array.from(bySuit.values()));
+  if (maxSuit === 3) score += 4;
+  if (maxSuit >= 4) score += 6;
+
+  // A high pressure
+  if (up.some((c) => c.rank === "A")) score += 2;
+  const highCount = up.filter((c) => ["K", "Q"].includes(c.rank)).length;
+  if (highCount >= 2) score += 1;
+
+  // ストレート判定（連結3枚以上なら加点）
+  const vals = up.map((c) => rankValue(c.rank)).sort((a, b) => a - b);
+  let run = 1;
+  for (let i = 1; i < vals.length; i++) {
+    if (vals[i] === vals[i - 1] + 1) {
+      run += 1;
+    } else {
+      run = 1;
+    }
+    if (run === 3) score += 4;
+    if (run === 4) score += 6;
+  }
+
+  return Math.min(score, 10);
+};
+
+/**
+ * 全相手からThreatスコアを計算（最大値を採用）
+ */
+export const scoreThreat = (opponents: VisiblePlayer[]): number => {
+  let max = 0;
+  for (const o of opponents) {
+    max = Math.max(max, scoreThreatForUp(o.up));
+  }
+  return max;
+};
+
+// ============================================================
+// Live判定
+// ============================================================
+
+/**
+ * フラッシュドローのLive判定
+ */
+export const liveForFlushSuit = (
+  suit: Suit,
+  deadSuitCount: Record<Suit, number>,
+): LiveGrade => {
+  const dead = deadSuitCount[suit] ?? 0;
+  if (dead <= 1) return "GOOD";
+  if (dead === 2) return "OK";
+  return "BAD"; // >=3
+};
+
+/**
+ * ペア改善のLive判定
+ */
+export const liveForPairImprove = (
+  pairRank: Rank,
+  deadRankCount: Record<Rank, number>,
+): LiveGrade => {
+  const dead = deadRankCount[pairRank] ?? 0;
+  if (dead === 0) return "GOOD";
+  if (dead === 1) return "OK";
+  return "BAD"; // >=2
+};
+
+/**
+ * ストレートドローのLive判定（必要ランクを指定）
+ */
+export const liveForStraight = (
+  neededRanks: Rank[],
+  deadRankCount: Record<Rank, number>,
+): LiveGrade => {
+  let maxDead = 0;
+  for (const r of neededRanks) {
+    maxDead = Math.max(maxDead, deadRankCount[r] ?? 0);
+  }
+  if (maxDead === 0) return "GOOD";
+  if (maxDead === 1) return "OK";
+  return "BAD"; // >=2
+};

--- a/src/domain/cpu/studHi/visibleContext.ts
+++ b/src/domain/cpu/studHi/visibleContext.ts
@@ -1,0 +1,169 @@
+/**
+ * Stud Hi CPU Lv2: VisibleContext（中間表現）
+ *
+ * CPUが判断に必要な見える情報のみを抽出した構造体。
+ * 仕様: docs/cpu_Lv2/VisibleContext_仕様書.md
+ */
+
+import type {
+  Card,
+  DealState,
+  Rank,
+  SeatIndex,
+  Street,
+  Suit,
+} from "../../types";
+
+// ============================================================
+// 型定義
+// ============================================================
+
+/** Liveの3段階評価 */
+export type LiveGrade = "GOOD" | "OK" | "BAD";
+
+/** 3rd StreetのTier評価 */
+export type Tier3rd = "S" | "A" | "B" | "C" | "D";
+
+/** 4th以降のCategory評価 (Made/Draw/Nothing) */
+export type Category = "M" | "D" | "N";
+
+/** 相手プレイヤーの公開情報 */
+export interface VisiblePlayer {
+  seat: number;
+  active: boolean;
+  up: Card[];
+  downCount: number;
+}
+
+/** CPU判断用の中間表現 */
+export interface VisibleContext {
+  street: Street;
+  me: {
+    seat: number;
+    up: Card[];
+    down: Card[];
+  };
+  opponents: VisiblePlayer[];
+  aliveSeats: number[];
+  headsUp: boolean;
+
+  /** 公開されているデッドカード（相手全員のupCards、fold済み含む） */
+  deadUpCards: Card[];
+  deadRankCount: Record<Rank, number>;
+  deadSuitCount: Record<Suit, number>;
+
+  bringInSeat: number;
+}
+
+// ============================================================
+// 定数
+// ============================================================
+
+const SUITS: Suit[] = ["c", "d", "h", "s"];
+const RANKS: Rank[] = [
+  "A",
+  "K",
+  "Q",
+  "J",
+  "T",
+  "9",
+  "8",
+  "7",
+  "6",
+  "5",
+  "4",
+  "3",
+  "2",
+];
+
+// ============================================================
+// ヘルパー関数
+// ============================================================
+
+/**
+ * カード配列からランクごとの枚数をカウント
+ */
+export const makeRankCount = (cards: Card[]): Record<Rank, number> => {
+  const init = Object.fromEntries(RANKS.map((r) => [r, 0])) as Record<
+    Rank,
+    number
+  >;
+  for (const c of cards) {
+    init[c.rank] += 1;
+  }
+  return init;
+};
+
+/**
+ * カード配列からスートごとの枚数をカウント
+ */
+export const makeSuitCount = (cards: Card[]): Record<Suit, number> => {
+  const init = Object.fromEntries(SUITS.map((s) => [s, 0])) as Record<
+    Suit,
+    number
+  >;
+  for (const c of cards) {
+    init[c.suit] += 1;
+  }
+  return init;
+};
+
+// ============================================================
+// メイン関数
+// ============================================================
+
+/**
+ * DealState から VisibleContext を生成
+ *
+ * @param state - 現在のDealState
+ * @param meSeat - CPU自身のシートインデックス
+ * @returns VisibleContext
+ */
+export const buildVisibleContext = (
+  state: DealState,
+  meSeat: SeatIndex,
+): VisibleContext => {
+  const myHand = state.hands[meSeat] ?? { upCards: [], downCards: [] };
+  const me = {
+    seat: meSeat,
+    up: myHand.upCards ?? [],
+    down: myHand.downCards ?? [],
+  };
+
+  // 全プレイヤー情報を抽出
+  const players = state.players.map((p) => {
+    const hand = state.hands[p.seat] ?? { upCards: [], downCards: [] };
+    return {
+      seat: p.seat,
+      active: p.active,
+      up: hand.upCards ?? [],
+      downCount: (hand.downCards ?? []).length,
+    } satisfies VisiblePlayer;
+  });
+
+  // 自分以外を相手として抽出
+  const opponents = players.filter((p) => p.seat !== meSeat);
+
+  // アクティブな（フォールドしていない）席
+  const aliveSeats = players.filter((p) => p.active).map((p) => p.seat);
+
+  // ヘッズアップ判定
+  const headsUp = aliveSeats.length === 2;
+
+  // デッドカード = 自分以外の全upCards（fold済みプレイヤーも含む）
+  const deadUpCards = opponents.flatMap((p) => p.up);
+  const deadRankCount = makeRankCount(deadUpCards);
+  const deadSuitCount = makeSuitCount(deadUpCards);
+
+  return {
+    street: state.street,
+    me,
+    opponents,
+    aliveSeats,
+    headsUp,
+    deadUpCards,
+    deadRankCount,
+    deadSuitCount,
+    bringInSeat: state.bringInIndex,
+  };
+};

--- a/src/ui/components/settings/CpuLevelToggle.tsx
+++ b/src/ui/components/settings/CpuLevelToggle.tsx
@@ -1,5 +1,12 @@
 import type React from "react";
 import { useAppStore } from "../../../app/store/appStore";
+import type { CpuLevel } from "../../../app/types";
+
+const CPU_LEVEL_DESCRIPTIONS: Record<CpuLevel, string> = {
+  lv0: "CHECK/CALL優先（開発用）",
+  lv1: "状況に応じた意思決定",
+  lv2: "ルールベースの強い戦略（Stud Hi専用）",
+};
 
 export const CpuLevelToggle: React.FC = () => {
   const cpuLevel = useAppStore((state) => state.ui.cpuLevel);
@@ -11,17 +18,16 @@ export const CpuLevelToggle: React.FC = () => {
         <div>
           <div className="font-medium">CPUレベル</div>
           <div className="text-sm text-muted-foreground">
-            {cpuLevel === "lv0"
-              ? "Lv0: CHECK/CALL優先（開発用）"
-              : "Lv1: 状況に応じた意思決定"}
+            {CPU_LEVEL_DESCRIPTIONS[cpuLevel]}
           </div>
         </div>
         <select
           value={cpuLevel}
-          onChange={(e) => setCpuLevel(e.target.value as "lv0" | "lv1")}
+          onChange={(e) => setCpuLevel(e.target.value as CpuLevel)}
           className="px-3 py-2 rounded bg-background border border-border text-foreground"
         >
-          <option value="lv1">Lv1（戦略的）</option>
+          <option value="lv2">Lv2（強い）</option>
+          <option value="lv1">Lv1（標準）</option>
           <option value="lv0">Lv0（開発用）</option>
         </select>
       </div>

--- a/test/domain/cpu/decideStudHiLv2.test.ts
+++ b/test/domain/cpu/decideStudHiLv2.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, it } from "vitest";
+import { decideStudHiLv2 } from "../../../src/domain/cpu/decideStudHiLv2";
+import type { CpuDecisionContext } from "../../../src/domain/cpu/policy";
+import type { Card, DealState } from "../../../src/domain/types";
+
+/**
+ * decideStudHiLv2 のテスト
+ * 仕様: docs/cpu_Lv2/StudHi_CPU戦略_実装指示書.md §9
+ */
+describe("decideStudHiLv2", () => {
+  const createTestState = (overrides: Partial<DealState> = {}): DealState => ({
+    dealId: "test-deal",
+    gameType: "studHi",
+    playerCount: 2,
+    players: [
+      {
+        seat: 0,
+        kind: "human",
+        active: true,
+        stack: 900,
+        committedTotal: 100,
+        committedThisStreet: 40,
+      },
+      {
+        seat: 1,
+        kind: "cpu",
+        active: true,
+        stack: 850,
+        committedTotal: 150,
+        committedThisStreet: 40,
+      },
+    ],
+    seatOrder: ["player1", "player2"],
+    ante: 10,
+    bringIn: 20,
+    smallBet: 40,
+    bigBet: 80,
+    street: "3rd",
+    bringInIndex: 0,
+    currentActorIndex: 1,
+    pot: 40,
+    currentBet: 20,
+    raiseCount: 0,
+    pendingResponseCount: 1,
+    checksThisStreet: 0,
+    actionsThisStreet: [],
+    dealFinished: false,
+    deck: [],
+    rngSeed: "",
+    hands: {
+      0: {
+        downCards: [
+          { rank: "2", suit: "c" } as Card,
+          { rank: "3", suit: "c" } as Card,
+        ],
+        upCards: [{ rank: "8", suit: "h" } as Card],
+      },
+      1: {
+        downCards: [
+          { rank: "A", suit: "h" } as Card,
+          { rank: "A", suit: "c" } as Card,
+        ],
+        upCards: [{ rank: "K", suit: "s" } as Card],
+      },
+    },
+    eventLog: [],
+    ...overrides,
+  });
+
+  describe("合法性テスト", () => {
+    it("返すアクションがallowedActionsに含まれていること", () => {
+      const state = createTestState();
+      const ctx: CpuDecisionContext = {
+        state,
+        seat: 1,
+        allowedActions: ["CALL", "COMPLETE", "FOLD"],
+      };
+
+      const action = decideStudHiLv2(ctx);
+      expect(["CALL", "COMPLETE", "FOLD"]).toContain(action);
+    });
+
+    it("allowedActionsが1つの場合、そのアクションを返すこと", () => {
+      const state = createTestState();
+      const ctx: CpuDecisionContext = {
+        state,
+        seat: 1,
+        allowedActions: ["CALL"],
+      };
+
+      const action = decideStudHiLv2(ctx);
+      expect(action).toBe("CALL");
+    });
+  });
+
+  describe("3rd Street Tier判定", () => {
+    it("Tier S（ハイペア）でCOMPLETEを選択すること", () => {
+      const state = createTestState({
+        hands: {
+          0: {
+            downCards: [
+              { rank: "2", suit: "c" } as Card,
+              { rank: "3", suit: "c" } as Card,
+            ],
+            upCards: [{ rank: "8", suit: "h" } as Card],
+          },
+          1: {
+            downCards: [
+              { rank: "A", suit: "h" } as Card,
+              { rank: "A", suit: "c" } as Card, // ハイペア
+            ],
+            upCards: [{ rank: "K", suit: "s" } as Card],
+          },
+        },
+      });
+
+      const ctx: CpuDecisionContext = {
+        state,
+        seat: 1,
+        allowedActions: ["CALL", "COMPLETE", "FOLD"],
+      };
+
+      const action = decideStudHiLv2(ctx);
+      expect(action).toBe("COMPLETE");
+    });
+
+    it("Tier D（弱い手）でFOLDを選択すること", () => {
+      const state = createTestState({
+        hands: {
+          0: {
+            downCards: [
+              { rank: "A", suit: "h" } as Card,
+              { rank: "K", suit: "h" } as Card,
+            ],
+            upCards: [{ rank: "Q", suit: "h" } as Card],
+          },
+          1: {
+            downCards: [
+              { rank: "2", suit: "c" } as Card,
+              { rank: "4", suit: "d" } as Card,
+            ],
+            upCards: [{ rank: "6", suit: "s" } as Card],
+          },
+        },
+      });
+
+      const ctx: CpuDecisionContext = {
+        state,
+        seat: 1,
+        allowedActions: ["CALL", "COMPLETE", "FOLD"],
+      };
+
+      const action = decideStudHiLv2(ctx);
+      // Tier DならFOLD寄り
+      expect(["FOLD", "CALL"]).toContain(action);
+    });
+  });
+
+  describe("5th Street Category分岐", () => {
+    it("Category N（Nothing）で相手BET → FOLDを選択すること", () => {
+      const state = createTestState({
+        street: "5th",
+        currentBet: 80,
+        hands: {
+          0: {
+            downCards: [
+              { rank: "A", suit: "s" } as Card,
+              { rank: "K", suit: "s" } as Card,
+            ],
+            upCards: [
+              { rank: "Q", suit: "s" } as Card,
+              { rank: "J", suit: "d" } as Card,
+              { rank: "T", suit: "h" } as Card,
+            ],
+          },
+          1: {
+            downCards: [
+              { rank: "2", suit: "c" } as Card,
+              { rank: "4", suit: "h" } as Card,
+            ],
+            upCards: [
+              { rank: "6", suit: "d" } as Card,
+              { rank: "8", suit: "c" } as Card,
+              { rank: "9", suit: "s" } as Card,
+            ],
+          },
+        },
+      });
+
+      const ctx: CpuDecisionContext = {
+        state,
+        seat: 1,
+        allowedActions: ["CALL", "RAISE", "FOLD"],
+      };
+
+      const action = decideStudHiLv2(ctx);
+      // Category N → FOLD を優先
+      expect(["FOLD", "CALL"]).toContain(action);
+    });
+
+    it("Category M（Made）で低Threat → CALL/RAISEを選択すること", () => {
+      const state = createTestState({
+        street: "5th",
+        currentBet: 80,
+        hands: {
+          0: {
+            downCards: [
+              { rank: "2", suit: "c" } as Card,
+              { rank: "3", suit: "d" } as Card,
+            ],
+            upCards: [
+              { rank: "5", suit: "s" } as Card,
+              { rank: "6", suit: "h" } as Card,
+              { rank: "7", suit: "c" } as Card,
+            ],
+          },
+          1: {
+            downCards: [
+              { rank: "A", suit: "h" } as Card,
+              { rank: "A", suit: "c" } as Card, // ペア
+            ],
+            upCards: [
+              { rank: "K", suit: "s" } as Card,
+              { rank: "Q", suit: "d" } as Card,
+              { rank: "J", suit: "h" } as Card,
+            ],
+          },
+        },
+      });
+
+      const ctx: CpuDecisionContext = {
+        state,
+        seat: 1,
+        allowedActions: ["CALL", "RAISE", "FOLD"],
+      };
+
+      const action = decideStudHiLv2(ctx);
+      // Category M で Threat低 → CALL または RAISE
+      expect(["CALL", "RAISE"]).toContain(action);
+    });
+  });
+
+  describe("Bring-in判定", () => {
+    it("Bring-in担当でTier S → COMPLETEを選択すること", () => {
+      const state = createTestState({
+        bringInIndex: 1,
+        currentActorIndex: 1,
+        currentBet: 0,
+        hands: {
+          0: {
+            downCards: [
+              { rank: "2", suit: "c" } as Card,
+              { rank: "3", suit: "d" } as Card,
+            ],
+            upCards: [{ rank: "8", suit: "h" } as Card],
+          },
+          1: {
+            downCards: [
+              { rank: "K", suit: "h" } as Card,
+              { rank: "K", suit: "c" } as Card, // ハイペア
+            ],
+            upCards: [{ rank: "A", suit: "s" } as Card],
+          },
+        },
+      });
+
+      const ctx: CpuDecisionContext = {
+        state,
+        seat: 1,
+        allowedActions: ["BRING_IN", "COMPLETE"],
+      };
+
+      const action = decideStudHiLv2(ctx);
+      // Tier S なら COMPLETE
+      expect(action).toBe("COMPLETE");
+    });
+
+    it("Bring-in担当でTier D → BRING_INを選択すること", () => {
+      const state = createTestState({
+        bringInIndex: 1,
+        currentActorIndex: 1,
+        currentBet: 0,
+        hands: {
+          0: {
+            downCards: [
+              { rank: "A", suit: "h" } as Card,
+              { rank: "K", suit: "h" } as Card,
+            ],
+            upCards: [{ rank: "Q", suit: "h" } as Card],
+          },
+          1: {
+            downCards: [
+              { rank: "2", suit: "c" } as Card,
+              { rank: "4", suit: "d" } as Card,
+            ],
+            upCards: [{ rank: "6", suit: "s" } as Card],
+          },
+        },
+      });
+
+      const ctx: CpuDecisionContext = {
+        state,
+        seat: 1,
+        allowedActions: ["BRING_IN", "COMPLETE"],
+      };
+
+      const action = decideStudHiLv2(ctx);
+      // Tier D なら BRING_IN
+      expect(action).toBe("BRING_IN");
+    });
+  });
+});

--- a/test/domain/cpu/studHi/eval.test.ts
+++ b/test/domain/cpu/studHi/eval.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+import {
+  evalCategory,
+  evalTier3rd,
+  liveForFlushSuit,
+  liveForPairImprove,
+  scoreThreat,
+  scoreThreatForUp,
+} from "../../../../src/domain/cpu/studHi/eval";
+import type { Card, Rank, Suit } from "../../../../src/domain/types";
+
+/**
+ * 評価関数のテスト
+ */
+describe("eval", () => {
+  // ヘルパー: 空のdeadCount
+  const emptyRankCount = (): Record<Rank, number> =>
+    Object.fromEntries(
+      ["A", "K", "Q", "J", "T", "9", "8", "7", "6", "5", "4", "3", "2"].map(
+        (r) => [r, 0],
+      ),
+    ) as Record<Rank, number>;
+
+  const emptySuitCount = (): Record<Suit, number> =>
+    ({ c: 0, d: 0, h: 0, s: 0 }) as Record<Suit, number>;
+
+  describe("evalTier3rd", () => {
+    describe("Tier S", () => {
+      it("Trips → S", () => {
+        const cards: Card[] = [
+          { rank: "7", suit: "h" },
+          { rank: "7", suit: "c" },
+          { rank: "7", suit: "d" },
+        ];
+        expect(evalTier3rd(cards, emptyRankCount(), emptySuitCount())).toBe(
+          "S",
+        );
+      });
+
+      it("隠れハイペア（JJ+） → S", () => {
+        const cards: Card[] = [
+          { rank: "K", suit: "h" },
+          { rank: "K", suit: "c" },
+          { rank: "4", suit: "d" },
+        ];
+        expect(evalTier3rd(cards, emptyRankCount(), emptySuitCount())).toBe(
+          "S",
+        );
+      });
+    });
+
+    describe("Tier A", () => {
+      it("隠れミドルペア（77-TT） → A", () => {
+        const cards: Card[] = [
+          { rank: "9", suit: "h" },
+          { rank: "9", suit: "c" },
+          { rank: "2", suit: "d" },
+        ];
+        expect(evalTier3rd(cards, emptyRankCount(), emptySuitCount())).toBe(
+          "A",
+        );
+      });
+
+      it("A-high 3フラ + Live良 → A", () => {
+        const cards: Card[] = [
+          { rank: "A", suit: "s" },
+          { rank: "6", suit: "s" },
+          { rank: "T", suit: "s" },
+        ];
+        expect(evalTier3rd(cards, emptyRankCount(), emptySuitCount())).toBe(
+          "A",
+        );
+      });
+    });
+
+    describe("Tier B", () => {
+      it("ローペア（22-66） → B", () => {
+        const cards: Card[] = [
+          { rank: "4", suit: "h" },
+          { rank: "4", suit: "c" },
+          { rank: "Q", suit: "d" },
+        ];
+        expect(evalTier3rd(cards, emptyRankCount(), emptySuitCount())).toBe(
+          "B",
+        );
+      });
+
+      it("低位3フラ → B", () => {
+        const cards: Card[] = [
+          { rank: "7", suit: "d" },
+          { rank: "3", suit: "d" },
+          { rank: "2", suit: "d" },
+        ];
+        expect(evalTier3rd(cards, emptyRankCount(), emptySuitCount())).toBe(
+          "B",
+        );
+      });
+    });
+
+    describe("Tier C", () => {
+      it("高ドア単体（J/Q/K/A） → C", () => {
+        const cards: Card[] = [
+          { rank: "Q", suit: "h" },
+          { rank: "5", suit: "c" },
+          { rank: "2", suit: "d" },
+        ];
+        expect(evalTier3rd(cards, emptyRankCount(), emptySuitCount())).toBe(
+          "C",
+        );
+      });
+
+      it("3フラでdeadSuit>=3 → 2段階降格（A→C）", () => {
+        const cards: Card[] = [
+          { rank: "A", suit: "s" },
+          { rank: "K", suit: "s" },
+          { rank: "Q", suit: "s" },
+        ];
+        const deadSuit = { ...emptySuitCount(), s: 3 };
+        expect(evalTier3rd(cards, emptyRankCount(), deadSuit)).toBe("C");
+      });
+    });
+
+    describe("Tier D", () => {
+      it("低いドア単体 → D", () => {
+        const cards: Card[] = [
+          { rank: "6", suit: "h" },
+          { rank: "3", suit: "c" },
+          { rank: "2", suit: "d" },
+        ];
+        expect(evalTier3rd(cards, emptyRankCount(), emptySuitCount())).toBe(
+          "D",
+        );
+      });
+    });
+  });
+
+  describe("evalCategory", () => {
+    it("ペアあり → M", () => {
+      const cards: Card[] = [
+        { rank: "T", suit: "h" },
+        { rank: "T", suit: "c" },
+        { rank: "5", suit: "d" },
+        { rank: "3", suit: "s" },
+      ];
+      expect(evalCategory(cards, emptyRankCount(), emptySuitCount())).toBe("M");
+    });
+
+    it("4フラ → D", () => {
+      const cards: Card[] = [
+        { rank: "A", suit: "h" },
+        { rank: "K", suit: "h" },
+        { rank: "Q", suit: "h" },
+        { rank: "J", suit: "h" },
+        { rank: "2", suit: "c" },
+      ];
+      expect(evalCategory(cards, emptyRankCount(), emptySuitCount())).toBe("D");
+    });
+
+    it("ペアなし・ドローなし → N", () => {
+      const cards: Card[] = [
+        { rank: "A", suit: "h" },
+        { rank: "K", suit: "c" },
+        { rank: "8", suit: "d" },
+        { rank: "5", suit: "s" },
+        { rank: "2", suit: "h" },
+      ];
+      expect(evalCategory(cards, emptyRankCount(), emptySuitCount())).toBe("N");
+    });
+  });
+
+  describe("scoreThreat", () => {
+    it("オープンペアup → +5", () => {
+      const up: Card[] = [
+        { rank: "K", suit: "h" },
+        { rank: "K", suit: "c" },
+      ];
+      expect(scoreThreatForUp(up)).toBeGreaterThanOrEqual(5);
+    });
+
+    it("4フラup → +6", () => {
+      const up: Card[] = [
+        { rank: "A", suit: "h" },
+        { rank: "K", suit: "h" },
+        { rank: "Q", suit: "h" },
+        { rank: "J", suit: "h" },
+      ];
+      expect(scoreThreatForUp(up)).toBeGreaterThanOrEqual(6);
+    });
+
+    it("A含む → +2", () => {
+      const up: Card[] = [{ rank: "A", suit: "h" }];
+      expect(scoreThreatForUp(up)).toBeGreaterThanOrEqual(2);
+    });
+
+    it("scoreThreat は最大値を返す", () => {
+      const opponents = [
+        {
+          seat: 0,
+          active: true,
+          up: [{ rank: "2", suit: "c" } as Card],
+          downCount: 2,
+        },
+        {
+          seat: 2,
+          active: true,
+          up: [{ rank: "A", suit: "h" } as Card],
+          downCount: 2,
+        },
+      ];
+      expect(scoreThreat(opponents)).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe("Live判定", () => {
+    it("liveForFlushSuit: deadSuit <= 1 → GOOD", () => {
+      expect(liveForFlushSuit("h", { c: 0, d: 0, h: 1, s: 0 })).toBe("GOOD");
+    });
+
+    it("liveForFlushSuit: deadSuit == 2 → OK", () => {
+      expect(liveForFlushSuit("h", { c: 0, d: 0, h: 2, s: 0 })).toBe("OK");
+    });
+
+    it("liveForFlushSuit: deadSuit >= 3 → BAD", () => {
+      expect(liveForFlushSuit("h", { c: 0, d: 0, h: 3, s: 0 })).toBe("BAD");
+    });
+
+    it("liveForPairImprove: dead == 0 → GOOD", () => {
+      expect(liveForPairImprove("K", emptyRankCount())).toBe("GOOD");
+    });
+
+    it("liveForPairImprove: dead == 1 → OK", () => {
+      const deadRank = { ...emptyRankCount(), K: 1 };
+      expect(liveForPairImprove("K", deadRank)).toBe("OK");
+    });
+
+    it("liveForPairImprove: dead >= 2 → BAD", () => {
+      const deadRank = { ...emptyRankCount(), K: 2 };
+      expect(liveForPairImprove("K", deadRank)).toBe("BAD");
+    });
+  });
+});

--- a/test/domain/cpu/studHi/visibleContext.test.ts
+++ b/test/domain/cpu/studHi/visibleContext.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildVisibleContext,
+  makeRankCount,
+  makeSuitCount,
+} from "../../../../src/domain/cpu/studHi/visibleContext";
+import type { Card, DealState } from "../../../../src/domain/types";
+
+/**
+ * VisibleContext のテスト
+ */
+describe("VisibleContext", () => {
+  const createTestState = (overrides: Partial<DealState> = {}): DealState => ({
+    dealId: "test-deal",
+    gameType: "studHi",
+    playerCount: 3,
+    players: [
+      {
+        seat: 0,
+        kind: "human",
+        active: true,
+        stack: 900,
+        committedTotal: 100,
+        committedThisStreet: 40,
+      },
+      {
+        seat: 1,
+        kind: "cpu",
+        active: true,
+        stack: 850,
+        committedTotal: 150,
+        committedThisStreet: 40,
+      },
+      {
+        seat: 2,
+        kind: "cpu",
+        active: false, // フォールド済み
+        stack: 800,
+        committedTotal: 50,
+        committedThisStreet: 0,
+      },
+    ],
+    seatOrder: ["player1", "player2", "player3"],
+    ante: 10,
+    bringIn: 20,
+    smallBet: 40,
+    bigBet: 80,
+    street: "4th",
+    bringInIndex: 0,
+    currentActorIndex: 1,
+    pot: 250,
+    currentBet: 40,
+    raiseCount: 0,
+    pendingResponseCount: 1,
+    checksThisStreet: 0,
+    actionsThisStreet: [],
+    dealFinished: false,
+    deck: [],
+    rngSeed: "",
+    hands: {
+      0: {
+        downCards: [
+          { rank: "A", suit: "h" } as Card,
+          { rank: "K", suit: "h" } as Card,
+        ],
+        upCards: [
+          { rank: "Q", suit: "h" } as Card,
+          { rank: "J", suit: "h" } as Card,
+        ],
+      },
+      1: {
+        downCards: [
+          { rank: "T", suit: "c" } as Card,
+          { rank: "9", suit: "c" } as Card,
+        ],
+        upCards: [
+          { rank: "8", suit: "c" } as Card,
+          { rank: "7", suit: "c" } as Card,
+        ],
+      },
+      2: {
+        downCards: [
+          { rank: "2", suit: "s" } as Card,
+          { rank: "3", suit: "s" } as Card,
+        ],
+        upCards: [{ rank: "4", suit: "s" } as Card],
+      },
+    },
+    eventLog: [],
+    ...overrides,
+  });
+
+  describe("buildVisibleContext", () => {
+    it("自分の情報（down + up）が正しく取得されること", () => {
+      const state = createTestState();
+      const ctx = buildVisibleContext(state, 1);
+
+      expect(ctx.me.seat).toBe(1);
+      expect(ctx.me.down).toHaveLength(2);
+      expect(ctx.me.up).toHaveLength(2);
+      expect(ctx.me.down[0].rank).toBe("T");
+      expect(ctx.me.up[0].rank).toBe("8");
+    });
+
+    it("相手の情報（upのみ）が正しく取得されること", () => {
+      const state = createTestState();
+      const ctx = buildVisibleContext(state, 1);
+
+      expect(ctx.opponents).toHaveLength(2);
+      // seat 0
+      const opp0 = ctx.opponents.find((o) => o.seat === 0);
+      expect(opp0?.up).toHaveLength(2);
+      expect(opp0?.downCount).toBe(2);
+      // seat 2
+      const opp2 = ctx.opponents.find((o) => o.seat === 2);
+      expect(opp2?.up).toHaveLength(1);
+    });
+
+    it("aliveSeatsがactiveなプレイヤーのみを含むこと", () => {
+      const state = createTestState();
+      const ctx = buildVisibleContext(state, 1);
+
+      expect(ctx.aliveSeats).toEqual([0, 1]);
+      expect(ctx.aliveSeats).not.toContain(2);
+    });
+
+    it("headsUpが2人の場合にtrueになること", () => {
+      const state = createTestState();
+      const ctx = buildVisibleContext(state, 1);
+
+      expect(ctx.headsUp).toBe(true);
+    });
+
+    it("deadUpCardsが相手全員のupCardsを含むこと（fold済みも含む）", () => {
+      const state = createTestState();
+      const ctx = buildVisibleContext(state, 1);
+
+      // seat 0: 2枚, seat 2: 1枚 = 合計3枚
+      expect(ctx.deadUpCards).toHaveLength(3);
+    });
+
+    it("deadRankCountが正しくカウントされること", () => {
+      const state = createTestState();
+      const ctx = buildVisibleContext(state, 1);
+
+      expect(ctx.deadRankCount["Q"]).toBe(1);
+      expect(ctx.deadRankCount["J"]).toBe(1);
+      expect(ctx.deadRankCount["4"]).toBe(1);
+    });
+
+    it("deadSuitCountが正しくカウントされること", () => {
+      const state = createTestState();
+      const ctx = buildVisibleContext(state, 1);
+
+      expect(ctx.deadSuitCount["h"]).toBe(2); // Q♥, J♥
+      expect(ctx.deadSuitCount["s"]).toBe(1); // 4♠
+    });
+  });
+
+  describe("makeRankCount", () => {
+    it("空配列の場合、全ランクが0になること", () => {
+      const result = makeRankCount([]);
+      expect(result["A"]).toBe(0);
+      expect(result["K"]).toBe(0);
+    });
+
+    it("カードのランクが正しくカウントされること", () => {
+      const cards: Card[] = [
+        { rank: "A", suit: "h" },
+        { rank: "A", suit: "s" },
+        { rank: "K", suit: "c" },
+      ];
+      const result = makeRankCount(cards);
+
+      expect(result["A"]).toBe(2);
+      expect(result["K"]).toBe(1);
+      expect(result["Q"]).toBe(0);
+    });
+  });
+
+  describe("makeSuitCount", () => {
+    it("空配列の場合、全スートが0になること", () => {
+      const result = makeSuitCount([]);
+      expect(result["h"]).toBe(0);
+      expect(result["s"]).toBe(0);
+    });
+
+    it("カードのスートが正しくカウントされること", () => {
+      const cards: Card[] = [
+        { rank: "A", suit: "h" },
+        { rank: "K", suit: "h" },
+        { rank: "Q", suit: "h" },
+        { rank: "J", suit: "s" },
+      ];
+      const result = makeSuitCount(cards);
+
+      expect(result["h"]).toBe(3);
+      expect(result["s"]).toBe(1);
+      expect(result["c"]).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## 概要
Stud Hi用のCPU Lv2戦略（ルールベースで強い）を実装しました。

## 変更内容

### 新規ファイル（5件）
- `src/domain/cpu/studHi/visibleContext.ts` - CPU判断用中間表現
- `src/domain/cpu/studHi/eval.ts` - Tier/Threat/Live評価関数
- `src/domain/cpu/decideStudHiLv2.ts` - ストリート別意思決定ロジック
- `src/domain/cpu/decideLv2.ts` - Lv2統括

### 変更ファイル（4件）
- `src/domain/cpu/policy.ts` - cpuLv2を追加
- `src/app/types.ts` - CpuLevel型にlv2を追加
- `src/domain/cpu/runner.ts` - lv2対応
- `src/ui/components/settings/CpuLevelToggle.tsx` - Lv2オプション追加

### テスト（41件追加）
- `test/domain/cpu/studHi/visibleContext.test.ts` (11件)
- `test/domain/cpu/studHi/eval.test.ts` (22件)
- `test/domain/cpu/decideStudHiLv2.test.ts` (8件)

## 実装仕様
- **3rd Street**: Tier判定（S/A/B/C/D）に基づく参加/スチール判定
- **4th Street**: Made→BET、Draw+低Threat→セミブラフ
- **5th Street以降**: Category N（Nothing）でFOLDを優先（強いCPUの核）
- **Razz/Stud8**: Lv2選択時はLv1にフォールバック

## 検証
- `npm run lint` ✅
- `npm run test` ✅ (254件パス)

Closes #99