### PR TITLE
#106 feat: CPUのデフォルトレベルをLv2に変更

### DIFF
--- a/src/app/store/appStore.ts
+++ b/src/app/store/appStore.ts
@@ -66,7 +66,7 @@ const INITIAL_UI: UiState = {
   screen: "SETUP",
   selectedDealId: null,
   displayUnit: "points",
-  cpuLevel: "lv1",
+  cpuLevel: "lv2",
 };
 
 const INITIAL_FULL_STORE: FullStore = {

--- a/src/domain/cpu/runner.ts
+++ b/src/domain/cpu/runner.ts
@@ -17,7 +17,7 @@ export type CpuLevel = "lv0" | "lv1" | "lv2";
 export const runCpuTurn = (
   state: DealState,
   seat: number,
-  cpuLevel: CpuLevel = "lv1",
+  cpuLevel: CpuLevel = "lv2",
 ): { nextState: DealState; event: Event } | null => {
   // 終了チェック
   if (state.dealFinished) return null;


### PR DESCRIPTION
## 概要
CPUの強さのデフォルト値をLv1からLv2に変更しました。

## 変更内容
| ファイル | 変更内容 |
|---------|---------|
| `src/app/store/appStore.ts` | `cpuLevel: "lv1"` → `cpuLevel: "lv2"` |
| `src/domain/cpu/runner.ts` | デフォルト引数を `"lv1"` → `"lv2"` |

## 検証結果
- ✅ Lint通過
- ✅ テスト全427件通過

Closes #106