### PR TITLE
#108 fix: CPU設定画面を非表示にする

### DIFF
--- a/src/ui/components/settings/CpuLevelToggle.tsx
+++ b/src/ui/components/settings/CpuLevelToggle.tsx
@@ -5,7 +5,7 @@ import type { CpuLevel } from "../../../app/types";
 const CPU_LEVEL_DESCRIPTIONS: Record<CpuLevel, string> = {
   lv0: "CHECK/CALL優先（開発用）",
   lv1: "状況に応じた意思決定",
-  lv2: "ルールベースの強い戦略（Stud Hi専用）",
+  lv2: "ルールベースの強い戦略",
 };
 
 export const CpuLevelToggle: React.FC = () => {

--- a/src/ui/pages/SettingsPage.tsx
+++ b/src/ui/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 import { useAppStore } from "../../app/store/appStore";
-import { CpuLevelToggle } from "../components/settings/CpuLevelToggle";
+// 開発用のため非表示: import { CpuLevelToggle } from "../components/settings/CpuLevelToggle";
 import { DangerZoneResetAll } from "../components/settings/DangerZoneResetAll";
 
 export const SettingsPage: React.FC = () => {
@@ -29,11 +29,12 @@ export const SettingsPage: React.FC = () => {
       {/* Content */}
       <div className="flex-1 overflow-y-auto p-6">
         <div className="max-w-2xl mx-auto space-y-8">
+          {/* 開発用のため非表示 */}
           {/* CPU Settings */}
-          <section>
+          {/* <section>
             <h2 className="text-xl font-semibold mb-4">CPU設定</h2>
             <CpuLevelToggle />
-          </section>
+          </section> */}
 
           {/* Data Info */}
           <section>


### PR DESCRIPTION
## 概要
開発用に追加したCPUレベル設定UIを、リリース向けに非表示にする。

## 変更内容
- `SettingsPage.tsx` でCPU設定セクションをコメントアウト
- `CpuLevelToggle.tsx` のLv2説明文を更新（Stud Hi専用→汎用）

## 検証
- ✅ lint通過
- ✅ format通過
- ✅ test通過（427テスト全て成功）
- ✅ ブラウザで動作確認済み

Closes #108