### PR TITLE
#110 feat: ハンド終了時にお気に入り追加できる星形アイコンボタンを追加

### DIFF
--- a/src/ui/components/TableView/ActionHistoryPanel.tsx
+++ b/src/ui/components/TableView/ActionHistoryPanel.tsx
@@ -7,12 +7,14 @@ import type {
 } from "../../../domain/types";
 import { UI_STRINGS } from "../../constants/uiStrings";
 import { getActionLabel, PLAYER_ACTION_TYPES } from "../../utils/actionLabel";
+import { FavoriteIconButton } from "../play/FavoriteIconButton";
 
 interface ActionHistoryPanelProps {
   eventLog: Event[];
   seatOrder: PlayerId[];
   players: GamePlayer[];
   dealIndex: number;
+  dealId?: string;
 }
 
 // ストリートの日本語ラベル
@@ -27,6 +29,7 @@ export const ActionHistoryPanel: React.FC<ActionHistoryPanelProps> = ({
   seatOrder,
   players,
   dealIndex,
+  dealId,
 }) => {
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -113,10 +116,11 @@ export const ActionHistoryPanel: React.FC<ActionHistoryPanelProps> = ({
 
   return (
     <div className="absolute top-4 right-4 z-20 w-56 max-h-52 rounded-lg border border-poker-gold/30 bg-poker-green/90 backdrop-blur-sm shadow-xl">
-      <div className="px-3 py-2 border-b border-white/10">
+      <div className="px-3 py-2 border-b border-white/10 flex items-center justify-between">
         <h3 className="text-xs font-bold text-poker-gold">
           {UI_STRINGS.PLAY.ACTION_HISTORY_TITLE(dealIndex + 1)}
         </h3>
+        {dealId && <FavoriteIconButton dealId={dealId} size="sm" />}
       </div>
       <div
         ref={scrollRef}

--- a/src/ui/components/TableView/TableView.tsx
+++ b/src/ui/components/TableView/TableView.tsx
@@ -104,6 +104,7 @@ export const TableView: React.FC<TableViewProps> = ({
         seatOrder={deal.seatOrder}
         players={game.players}
         dealIndex={dealIndex}
+        dealId={deal.dealId}
       />
       {/* テーブル中央のポット表示（ショーダウン時は非表示） */}
       {!deal.dealFinished && (

--- a/src/ui/components/play/FavoriteIconButton.tsx
+++ b/src/ui/components/play/FavoriteIconButton.tsx
@@ -1,0 +1,40 @@
+import type React from "react";
+import { useAppStore } from "../../../app/store/appStore";
+
+interface FavoriteIconButtonProps {
+  dealId: string;
+  size?: "sm" | "md";
+}
+
+export const FavoriteIconButton: React.FC<FavoriteIconButtonProps> = ({
+  dealId,
+  size = "md",
+}) => {
+  const favoriteDealIds = useAppStore(
+    (state) => state.fullStore.favoriteDealIds,
+  );
+  const toggleFavoriteDeal = useAppStore((state) => state.toggleFavoriteDeal);
+
+  const isFavorite = favoriteDealIds.includes(dealId);
+
+  const handleClick = () => {
+    toggleFavoriteDeal(dealId);
+  };
+
+  const sizeClasses = size === "sm" ? "w-6 h-6 text-sm" : "w-10 h-10 text-xl";
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={`${sizeClasses} flex items-center justify-center rounded-lg transition-all ${
+        isFavorite
+          ? "bg-yellow-500 text-white hover:bg-yellow-600 shadow-sm"
+          : "bg-muted text-muted-foreground hover:bg-muted/80"
+      }`}
+      title={isFavorite ? "お気に入り解除" : "お気に入り登録"}
+    >
+      {isFavorite ? "★" : "☆"}
+    </button>
+  );
+};


### PR DESCRIPTION
## 概要
ハンド終了時に「アクション履歴(#n)」ヘッダーの右隣に星形アイコンボタンを表示し、ハンド履歴をお気に入りに追加できるようにしました。

## 変更内容
- `FavoriteIconButton.tsx` - アイコンのみのお気に入りボタンを新規作成（sm/mdサイズ対応）
- `ActionHistoryPanel.tsx` - ヘッダーに星アイコンを追加
- `TableView.tsx` - ActionHistoryPanelにdealIdを渡すよう修正

## スクリーンショット
手動検証済み

## テスト結果
- ✅ Lint 通過
- ✅ Format 通過  
- ✅ テスト全427件通過

Closes #110