### PR TITLE
#112 fix: お気に入り登録済みハンドが直近10件から押し出されても削除されないよう修正

### DIFF
--- a/src/app/store/appStore.ts
+++ b/src/app/store/appStore.ts
@@ -29,21 +29,20 @@ import {
 const MAX_FULL_RECENT = 10;
 
 /**
- * フル保存のeviction処理（fullDealIdsに含まれないものを削除）
+ * フル保存のeviction処理（fullDealIds・favoriteDealIdsに含まれないものを削除）
  */
 const evictFullDeals = (state: AppState): void => {
-  const keepIds = new Set<string>(state.fullStore.fullDealIds);
+  // 直近10件 + お気に入り登録済みのIDを保持対象に含める
+  const keepIds = new Set<string>([
+    ...state.fullStore.fullDealIds,
+    ...state.fullStore.favoriteDealIds,
+  ]);
 
   for (const id of Object.keys(state.fullStore.fullDealsById)) {
     if (!keepIds.has(id)) {
       delete state.fullStore.fullDealsById[id];
     }
   }
-
-  // お気に入りも、フルが存在しないものは削除
-  state.fullStore.favoriteDealIds = state.fullStore.favoriteDealIds.filter(
-    (id) => keepIds.has(id),
-  );
 };
 
 export interface AppActions {


### PR DESCRIPTION
## 概要

お気に入り登録済みのハンドが直近10件（`fullDealIds`）から押し出された際に削除されてしまう問題を修正しました。

## 変更内容

### 修正ファイル

#### `src/app/store/appStore.ts`

`evictFullDeals` 関数を修正し、`keepIds` に `favoriteDealIds` も含めるようにしました。

```diff
 const evictFullDeals = (state: AppState): void => {
-  const keepIds = new Set<string>(state.fullStore.fullDealIds);
+  // 直近10件 + お気に入り登録済みのIDを保持対象に含める
+  const keepIds = new Set<string>([
+    ...state.fullStore.fullDealIds,
+    ...state.fullStore.favoriteDealIds,
+  ]);

   for (const id of Object.keys(state.fullStore.fullDealsById)) {
     if (!keepIds.has(id)) {
       delete state.fullStore.fullDealsById[id];
     }
   }
-
-  // お気に入りも、フルが存在しないものは削除
-  state.fullStore.favoriteDealIds = state.fullStore.favoriteDealIds.filter(
-    (id) => keepIds.has(id),
-  );
 };
```

### テスト追加

#### `test/app/storeFlow.test.ts`

`evictFullDeals` の挙動を検証するテストを2件追加しました：

1. **お気に入り登録済みハンドが fullDealIds から押し出されてもデータが保持されること**
2. **お気に入り解除されたハンドは fullDealIds から外れると削除されること**

## 検証結果

- ✅ 全429テスト通過（+2件）
- ✅ Lint / Format 通過

Closes #112