### PR TITLE
#114 feat: お気に入りアイコンをハンド終了時のみ表示

### DIFF
--- a/src/ui/components/TableView/ActionHistoryPanel.tsx
+++ b/src/ui/components/TableView/ActionHistoryPanel.tsx
@@ -15,6 +15,7 @@ interface ActionHistoryPanelProps {
   players: GamePlayer[];
   dealIndex: number;
   dealId?: string;
+  isDealFinished: boolean;
 }
 
 // ストリートの日本語ラベル
@@ -30,6 +31,7 @@ export const ActionHistoryPanel: React.FC<ActionHistoryPanelProps> = ({
   players,
   dealIndex,
   dealId,
+  isDealFinished,
 }) => {
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -120,7 +122,9 @@ export const ActionHistoryPanel: React.FC<ActionHistoryPanelProps> = ({
         <h3 className="text-xs font-bold text-poker-gold">
           {UI_STRINGS.PLAY.ACTION_HISTORY_TITLE(dealIndex + 1)}
         </h3>
-        {dealId && <FavoriteIconButton dealId={dealId} size="sm" />}
+        {dealId && isDealFinished && (
+          <FavoriteIconButton dealId={dealId} size="sm" />
+        )}
       </div>
       <div
         ref={scrollRef}

--- a/src/ui/components/TableView/TableView.tsx
+++ b/src/ui/components/TableView/TableView.tsx
@@ -105,6 +105,7 @@ export const TableView: React.FC<TableViewProps> = ({
         players={game.players}
         dealIndex={dealIndex}
         dealId={deal.dealId}
+        isDealFinished={deal.dealFinished}
       />
       {/* テーブル中央のポット表示（ショーダウン時は非表示） */}
       {!deal.dealFinished && (


### PR DESCRIPTION
## 概要
お気に入りアイコンボタンをハンド終了時のみ表示するよう変更。

## 変更内容
- `ActionHistoryPanel`に`isDealFinished`プロパティを追加
- `FavoriteIconButton`の表示条件を`dealId && isDealFinished`に変更
- `TableView`から`isDealFinished={deal.dealFinished}`を渡すよう修正

## テスト結果
- Lint: ✅ Pass
- Format: ✅ Pass
- Test: ✅ 429 tests passed

Closes #114